### PR TITLE
enums: use python Enum

### DIFF
--- a/mds/apis/agency_api/v0_x/vehicles.py
+++ b/mds/apis/agency_api/v0_x/vehicles.py
@@ -24,11 +24,11 @@ class DeviceSerializer(serializers.Serializer):
     )
     type = serializers.ChoiceField(
         source="category",
-        choices=enums.DEVICE_CATEGORY_CHOICES,
+        choices=enums.choices(enums.DEVICE_CATEGORY),
         help_text="Vehicle type.",
     )
     propulsion = serializers.ListSerializer(
-        child=serializers.ChoiceField(choices=enums.DEVICE_PROPULSION_CHOICES),
+        child=serializers.ChoiceField(choices=enums.choices(enums.DEVICE_PROPULSION)),
         help_text="Array of Propulsion Type.",
     )
     year = serializers.IntegerField(
@@ -40,12 +40,12 @@ class DeviceSerializer(serializers.Serializer):
     model = serializers.CharField(help_text="Vehicle Model.")
     status = serializers.ChoiceField(
         source="dn_status",
-        choices=enums.DEVICE_STATUS_CHOICES,
+        choices=enums.choices(enums.DEVICE_STATUS),
         help_text="Current vehicle status.",
     )
     prev_event = serializers.ChoiceField(
         source="latest_event.event_type",
-        choices=enums.EVENT_TYPE_CHOICES,
+        choices=enums.choices(enums.EVENT_TYPE),
         help_text="Last Vehicle Event.",
         allow_null=True,
     )
@@ -66,11 +66,11 @@ class DeviceRegisterSerializer(serializers.Serializer):
     )
     type = serializers.ChoiceField(
         source="category",
-        choices=enums.DEVICE_CATEGORY_CHOICES,
+        choices=enums.choices(enums.DEVICE_CATEGORY),
         help_text="Vehicle type.",
     )
     propulsion = serializers.ListSerializer(
-        child=serializers.ChoiceField(choices=enums.DEVICE_PROPULSION_CHOICES),
+        child=serializers.ChoiceField(choices=enums.choices(enums.DEVICE_PROPULSION)),
         help_text="Array of Propulsion Type.",
     )
     year = serializers.IntegerField(
@@ -103,7 +103,7 @@ class DeviceTelemetrySerializer(serializers.Serializer):
 
 class DeviceEventSerializer(serializers.Serializer):
     event_type = serializers.ChoiceField(
-        choices=enums.EVENT_TYPE_CHOICES, help_text="Vehicle event."
+        choices=enums.choices(enums.EVENT_TYPE), help_text="Vehicle event."
     )
     telemetry = DeviceTelemetrySerializer(
         write_only=True, help_text="Single point of telemetry."

--- a/mds/apis/prv_api/vehicles.py
+++ b/mds/apis/prv_api/vehicles.py
@@ -12,10 +12,12 @@ from mds.apis import utils
 
 class DeviceFilter(filters.FilterSet):
     id = filters.CharFilter(lookup_expr="icontains")
-    category = filters.MultipleChoiceFilter(choices=enums.DEVICE_CATEGORY_CHOICES)
+    category = filters.MultipleChoiceFilter(
+        choices=enums.choices(enums.DEVICE_CATEGORY)
+    )
     provider = filters.UUIDFilter()
     status = filters.MultipleChoiceFilter(
-        "dn_status", choices=enums.DEVICE_STATUS_CHOICES
+        "dn_status", choices=enums.choices(enums.DEVICE_STATUS)
     )
     registrationDateFrom = filters.IsoDateTimeFilter(
         "registration_date", lookup_expr="gte"
@@ -43,10 +45,10 @@ class DeviceSerializer(serializers.ModelSerializer):
         help_text="VIN (Vehicle Identification Number)"
     )
     category = serializers.ChoiceField(
-        enums.DEVICE_CATEGORY_CHOICES, help_text="Device type"
+        enums.choices(enums.DEVICE_CATEGORY), help_text="Device type"
     )
     propulsion = serializers.ListField(
-        child=serializers.ChoiceField(enums.DEVICE_PROPULSION_CHOICES),
+        child=serializers.ChoiceField(enums.choices(enums.DEVICE_PROPULSION)),
         help_text="Propulsion type(s)",
     )
     provider = serializers.CharField(
@@ -60,7 +62,7 @@ class DeviceSerializer(serializers.ModelSerializer):
         source="dn_gps_point", help_text="Latest GPS position"
     )
     status = serializers.ChoiceField(
-        enums.DEVICE_STATUS_CHOICES,
+        enums.choices(enums.DEVICE_STATUS),
         source="dn_status",
         help_text="Latest status",
         allow_null=True,

--- a/mds/enums.py
+++ b/mds/enums.py
@@ -1,45 +1,70 @@
-from django.utils.translation import ugettext_lazy as _
+import enum
+
+from django.utils.translation import pgettext_lazy
 
 
-HTTP_METHOD_CHOICES = [("POST", "POST"), ("PUT", "PUT"), ("DELETE", "DELETE")]
-DEVICE_STATUS_CHOICES = [
-    ("available", _("Available")),
-    ("reserved", _("Reserved")),
-    ("unavailable", _("Unavailable")),
-    ("removed", _("Removed")),
-]
-DEVICE_CATEGORY_CHOICES = [
-    ("bike", _("Bike")),
-    ("scooter", _("Scooter")),
-    ("car", _("Car")),
-]
-DEVICE_PROPULSION_CHOICES = [
-    ("electric", _("Electric")),
-    ("combustion", _("Combustion")),
-]
+def choices(enum):
+    """Convert an Enum to a Django-style "choices" iterator.
+    """
+    return [(member.name, member.value) for member in enum]
 
-EVENT_TYPE_CHOICES = [
-    ("service_start", _("Service start")),
-    ("trip_end", _("Trip end")),
-    ("rebalance_drop_off", _("Rebalance drop_off")),
-    ("maintenance_drop_off", _("Maintenance drop off")),
-    ("cancel_reservation", _("Cancel reservation")),
-    ("reserve", _("Reserve")),
-    ("trip_start", _("Trip start")),
-    ("trip_enter", _("Trip enter")),
-    ("trip_leave", _("Trip leave")),
-    ("register", _("Register")),
-    ("low_battery", _("Low battery")),
-    ("maintenance", _("Maintenance")),
-    ("service_end", _("Service end")),
-    ("rebalance_pick_up", _("Rebalance pick up")),
-    ("maintenance_pick_up", _("Maintenance pick up")),
-    ("deregister", _("Deregister")),
-    # this last event is not in the MDS spec
-    ("telemetry", _("Received telemetry")),
-]
 
-EVENT_INGESTION_SOURCES = [
-    ("push", "push"),  # pushed by the provider
-    ("pull", "pull"),  # pulled by agency (e.g. from the provider's API
-]
+DEVICE_STATUS = enum.Enum(
+    "Device status",
+    [
+        ("available", pgettext_lazy("Device status", "Available")),
+        ("reserved", pgettext_lazy("Device status", "Reserved")),
+        ("unavailable", pgettext_lazy("Device status", "Unavailable")),
+        ("removed", pgettext_lazy("Device status", "Removed")),
+    ],
+)
+
+DEVICE_CATEGORY = enum.Enum(
+    "Device category",
+    [
+        ("bike", pgettext_lazy("Device category", "Bike")),
+        ("scooter", pgettext_lazy("Device category", "Scooter")),
+        ("car", pgettext_lazy("Device category", "Car")),
+    ],
+)
+DEVICE_PROPULSION = enum.Enum(
+    "Device propulsion",
+    [
+        ("electric", pgettext_lazy("Device propulsion", "Electric")),
+        ("combustion", pgettext_lazy("Device propulsion", "Combustion")),
+    ],
+)
+
+EVENT_TYPE = enum.Enum(
+    "Event type",
+    [
+        ("service_start", pgettext_lazy("Event type", "Service start")),
+        ("trip_end", pgettext_lazy("Event type", "Trip end")),
+        ("rebalance_drop_off", pgettext_lazy("Event type", "Rebalance drop_off")),
+        ("maintenance_drop_off", pgettext_lazy("Event type", "Maintenance drop off")),
+        ("cancel_reservation", pgettext_lazy("Event type", "Cancel reservation")),
+        ("reserve", pgettext_lazy("Event type", "Reserve")),
+        ("trip_start", pgettext_lazy("Event type", "Trip start")),
+        ("trip_enter", pgettext_lazy("Event type", "Trip enter")),
+        ("trip_leave", pgettext_lazy("Event type", "Trip leave")),
+        ("register", pgettext_lazy("Event type", "Register")),
+        ("low_battery", pgettext_lazy("Event type", "Low battery")),
+        ("maintenance", pgettext_lazy("Event type", "Maintenance")),
+        ("service_end", pgettext_lazy("Event type", "Service end")),
+        ("rebalance_pick_up", pgettext_lazy("Event type", "Rebalance pick up")),
+        ("maintenance_pick_up", pgettext_lazy("Event type", "Maintenance pick up")),
+        ("deregister", pgettext_lazy("Event type", "Deregister")),
+        # this last event is not in the MDS spec
+        ("telemetry", pgettext_lazy("Event type", "Received telemetry")),
+    ],
+)
+
+EVENT_SOURCE = enum.Enum(
+    "Event source",
+    [
+        # push provider -> agency API
+        ("push", pgettext_lazy("Event source", "push")),
+        # pull agency <- provider API
+        ("pull", pgettext_lazy("Event source", "pull")),
+    ],
+)

--- a/mds/factories.py
+++ b/mds/factories.py
@@ -580,14 +580,12 @@ class Device(factory.DjangoModelFactory):
     provider = factory.SubFactory(Provider)
     identification_number = factory.Sequence(str)
     model = factory.Iterator(["bicycle-A", "car-B"])
-    category = factory.Iterator(choice[0] for choice in enums.DEVICE_CATEGORY_CHOICES)
-    propulsion = factory.Iterator(
-        [choice[0]] for choice in enums.DEVICE_PROPULSION_CHOICES
-    )
+    category = factory.Iterator(choice.name for choice in enums.DEVICE_CATEGORY)
+    propulsion = factory.Iterator([choice.name] for choice in enums.DEVICE_PROPULSION)
 
     dn_gps_point = factory.LazyFunction(get_random_point)
     dn_gps_timestamp = factory.LazyFunction(timezone.now)
-    dn_status = factory.Iterator(choice[0] for choice in enums.DEVICE_STATUS_CHOICES)
+    dn_status = factory.Iterator(choice.name for choice in enums.DEVICE_STATUS)
 
 
 class Area(factory.DjangoModelFactory):
@@ -640,7 +638,7 @@ class EventRecord(factory.DjangoModelFactory):
 
     device = factory.SubFactory(Device)
     saved_at = datetime.datetime(2018, 8, 1, tzinfo=pytz.utc)
-    event_type = factory.Iterator(c for c, _ in enums.EVENT_TYPE_CHOICES)
+    event_type = factory.Iterator(c.name for c in enums.EVENT_TYPE)
     properties = factory.Dict(
         {
             "trip_id": None,

--- a/mds/locale/en_US/LC_MESSAGES/django.po
+++ b/mds/locale/en_US/LC_MESSAGES/django.po
@@ -8,38 +8,164 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-12 15:33+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2019-01-21 13:58+0000\n"
+"PO-Revision-Date: 2019-01-08 10:43+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: en_US\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
+#: mds/access_control/authenticate.py:56
+msgid "Signature has expired."
+msgstr ""
+
+#: mds/access_control/authenticate.py:59
+msgid "Error decoding signature."
+msgstr ""
+
+#: mds/access_control/authenticate.py:92
+#, python-format
+msgid "Invalid payload, missing fields: %(fields)s"
+msgstr ""
+
+#: mds/enums.py:15
+msgctxt "Device status"
 msgid "Available"
 msgstr ""
 
+#: mds/enums.py:16
+msgctxt "Device status"
 msgid "Reserved"
 msgstr ""
 
+#: mds/enums.py:17
+msgctxt "Device status"
 msgid "Unavailable"
 msgstr ""
 
+#: mds/enums.py:18
+msgctxt "Device status"
 msgid "Removed"
 msgstr ""
 
+#: mds/enums.py:25
+msgctxt "Device category"
 msgid "Bike"
 msgstr ""
 
+#: mds/enums.py:26
+msgctxt "Device category"
 msgid "Scooter"
 msgstr ""
 
+#: mds/enums.py:27
+msgctxt "Device category"
 msgid "Car"
 msgstr ""
 
+#: mds/enums.py:33
+msgctxt "Device propulsion"
 msgid "Electric"
 msgstr ""
 
+#: mds/enums.py:34
+msgctxt "Device propulsion"
 msgid "Combustion"
+msgstr ""
+
+#: mds/enums.py:41
+msgctxt "Event type"
+msgid "Service start"
+msgstr ""
+
+#: mds/enums.py:42
+msgctxt "Event type"
+msgid "Trip end"
+msgstr ""
+
+#: mds/enums.py:43
+msgctxt "Event type"
+msgid "Rebalance drop_off"
+msgstr ""
+
+#: mds/enums.py:44
+msgctxt "Event type"
+msgid "Maintenance drop off"
+msgstr ""
+
+#: mds/enums.py:45
+msgctxt "Event type"
+msgid "Cancel reservation"
+msgstr ""
+
+#: mds/enums.py:46
+msgctxt "Event type"
+msgid "Reserve"
+msgstr ""
+
+#: mds/enums.py:47
+msgctxt "Event type"
+msgid "Trip start"
+msgstr ""
+
+#: mds/enums.py:48
+msgctxt "Event type"
+msgid "Trip enter"
+msgstr ""
+
+#: mds/enums.py:49
+msgctxt "Event type"
+msgid "Trip leave"
+msgstr ""
+
+#: mds/enums.py:50
+msgctxt "Event type"
+msgid "Register"
+msgstr ""
+
+#: mds/enums.py:51
+msgctxt "Event type"
+msgid "Low battery"
+msgstr ""
+
+#: mds/enums.py:52
+msgctxt "Event type"
+msgid "Maintenance"
+msgstr ""
+
+#: mds/enums.py:53
+msgctxt "Event type"
+msgid "Service end"
+msgstr ""
+
+#: mds/enums.py:54
+msgctxt "Event type"
+msgid "Rebalance pick up"
+msgstr ""
+
+#: mds/enums.py:55
+msgctxt "Event type"
+msgid "Maintenance pick up"
+msgstr ""
+
+#: mds/enums.py:56
+msgctxt "Event type"
+msgid "Deregister"
+msgstr ""
+
+#: mds/enums.py:58
+msgctxt "Event type"
+msgid "Received telemetry"
+msgstr ""
+
+#: mds/enums.py:66
+msgctxt "Event source"
+msgid "push"
+msgstr ""
+
+#: mds/enums.py:68
+msgctxt "Event source"
+msgid "pull"
 msgstr ""

--- a/mds/locale/fr_FR/LC_MESSAGES/django.po
+++ b/mds/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,47 +8,164 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-12 15:36+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"POT-Creation-Date: 2019-01-21 13:54+0000\n"
+"PO-Revision-Date: 2019-01-08 10:43+0000\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"Language: fr_FR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: mds/enums.py:6
+#: mds/access_control/authenticate.py:56
+msgid "Signature has expired."
+msgstr "La signature a expiré"
+
+#: mds/access_control/authenticate.py:59
+msgid "Error decoding signature."
+msgstr "Erreur de décodage de la signature"
+
+#: mds/access_control/authenticate.py:92
+#, python-format
+msgid "Invalid payload, missing fields: %(fields)s"
+msgstr "Contenu invalide, champs manquants: %(fields)s"
+
+#: mds/enums.py:15
+msgctxt "Device status"
 msgid "Available"
 msgstr "Disponible"
 
-#: mds/enums.py:7
+#: mds/enums.py:16
+msgctxt "Device status"
 msgid "Reserved"
 msgstr "Réservé"
 
-#: mds/enums.py:8
+#: mds/enums.py:17
+msgctxt "Device status"
 msgid "Unavailable"
 msgstr "Indisponible"
 
-#: mds/enums.py:9
+#: mds/enums.py:18
+msgctxt "Device status"
 msgid "Removed"
 msgstr "Supprimé"
 
-#: mds/enums.py:12
+#: mds/enums.py:25
+msgctxt "Device category"
 msgid "Bike"
 msgstr "Vélo"
 
-#: mds/enums.py:13
+#: mds/enums.py:26
+msgctxt "Device category"
 msgid "Scooter"
-msgstr "Scooter"
+msgstr "Trottinette"
 
-#: mds/enums.py:14
+#: mds/enums.py:27
+msgctxt "Device category"
 msgid "Car"
 msgstr "Voiture"
 
-#: mds/enums.py:17
+#: mds/enums.py:33
+msgctxt "Device propulsion"
 msgid "Electric"
 msgstr "Électrique"
 
-#: mds/enums.py:18
+#: mds/enums.py:34
+msgctxt "Device propulsion"
 msgid "Combustion"
 msgstr "Combustion"
+
+#: mds/enums.py:41
+msgctxt "Event type"
+msgid "Service start"
+msgstr "Début de service"
+
+#: mds/enums.py:42
+msgctxt "Event type"
+msgid "Trip end"
+msgstr "Fin de parcours"
+
+#: mds/enums.py:43
+msgctxt "Event type"
+msgid "Rebalance drop_off"
+msgstr "Dépôt pour rééquilibrage"
+
+#: mds/enums.py:44
+msgctxt "Event type"
+msgid "Maintenance drop off"
+msgstr "Dépôt pour maintenance"
+
+#: mds/enums.py:45
+msgctxt "Event type"
+msgid "Cancel reservation"
+msgstr "Annulation de réservation"
+
+#: mds/enums.py:46
+msgctxt "Event type"
+msgid "Reserve"
+msgstr "Réservation"
+
+#: mds/enums.py:47
+msgctxt "Event type"
+msgid "Trip start"
+msgstr "Début de parcours"
+
+#: mds/enums.py:48
+msgctxt "Event type"
+msgid "Trip enter"
+msgstr "Entrée en parcours"
+
+#: mds/enums.py:49
+msgctxt "Event type"
+msgid "Trip leave"
+msgstr "Sortie de parcours"
+
+#: mds/enums.py:50
+msgctxt "Event type"
+msgid "Register"
+msgstr "Enregistrement"
+
+#: mds/enums.py:51
+msgctxt "Event type"
+msgid "Low battery"
+msgstr "Batterie faible"
+
+#: mds/enums.py:52
+msgctxt "Event type"
+msgid "Maintenance"
+msgstr "Maintenance"
+
+#: mds/enums.py:53
+msgctxt "Event type"
+msgid "Service end"
+msgstr "Fin de service"
+
+#: mds/enums.py:54
+msgctxt "Event type"
+msgid "Rebalance pick up"
+msgstr "Retrait pour rééquilibrage"
+
+#: mds/enums.py:55
+msgctxt "Event type"
+msgid "Maintenance pick up"
+msgstr "Retrait pour maintenance"
+
+#: mds/enums.py:56
+msgctxt "Event type"
+msgid "Deregister"
+msgstr "Désinscription"
+
+#: mds/enums.py:58
+msgctxt "Event type"
+msgid "Received telemetry"
+msgstr "Télémétrie reçue"
+
+#: mds/enums.py:66
+msgctxt "Event source"
+msgid "push"
+msgstr "push"
+
+#: mds/enums.py:68
+msgctxt "Event source"
+msgid "pull"
+msgstr "pull"

--- a/mds/migrations/0001_initial.py
+++ b/mds/migrations/0001_initial.py
@@ -15,78 +15,213 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []
 
     operations = [
         migrations.CreateModel(
-            name='Area',
+            name="Area",
             fields=[
-                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
-                ('creation_date', models.DateTimeField(default=django.utils.timezone.now)),
-                ('deletion_date', models.DateTimeField(null=True)),
-                ('label', mds.models.UnboundedCharField(null=True)),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "creation_date",
+                    models.DateTimeField(default=django.utils.timezone.now),
+                ),
+                ("deletion_date", models.DateTimeField(null=True)),
+                ("label", mds.models.UnboundedCharField(null=True)),
             ],
         ),
         migrations.CreateModel(
-            name='Device',
+            name="Device",
             fields=[
-                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
-                ('registration_date', models.DateTimeField(default=django.utils.timezone.now)),
-                ('identification_number', mds.models.UnboundedCharField()),
-                ('category', mds.models.UnboundedCharField(choices=[('bike', 'Bike'), ('scooter', 'Scooter'), ('car', 'Car')])),
-                ('model', mds.models.UnboundedCharField(default=str)),
-                ('propulsion', django.contrib.postgres.fields.ArrayField(base_field=mds.models.UnboundedCharField(choices=[('electric', 'Electric'), ('combustion', 'Combustion')]), size=None)),
-                ('year_manufactured', models.IntegerField(null=True)),
-                ('manufacturer', mds.models.UnboundedCharField(default=str)),
-                ('dn_gps_point', django.contrib.gis.db.models.fields.PointField(null=True, srid=4326)),
-                ('dn_gps_timestamp', models.DateTimeField(null=True)),
-                ('dn_status', mds.models.UnboundedCharField(choices=[('available', 'Available'), ('reserved', 'Reserved'), ('unavailable', 'Unavailable'), ('removed', 'Removed')], default='unavailable')),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "registration_date",
+                    models.DateTimeField(default=django.utils.timezone.now),
+                ),
+                ("identification_number", mds.models.UnboundedCharField()),
+                (
+                    "category",
+                    mds.models.UnboundedCharField(
+                        choices=[
+                            ("bike", "Bike"),
+                            ("scooter", "Scooter"),
+                            ("car", "Car"),
+                        ]
+                    ),
+                ),
+                ("model", mds.models.UnboundedCharField(default=str)),
+                (
+                    "propulsion",
+                    django.contrib.postgres.fields.ArrayField(
+                        base_field=mds.models.UnboundedCharField(
+                            choices=[
+                                ("electric", "Electric"),
+                                ("combustion", "Combustion"),
+                            ]
+                        ),
+                        size=None,
+                    ),
+                ),
+                ("year_manufactured", models.IntegerField(null=True)),
+                ("manufacturer", mds.models.UnboundedCharField(default=str)),
+                (
+                    "dn_gps_point",
+                    django.contrib.gis.db.models.fields.PointField(
+                        null=True, srid=4326
+                    ),
+                ),
+                ("dn_gps_timestamp", models.DateTimeField(null=True)),
+                (
+                    "dn_status",
+                    mds.models.UnboundedCharField(
+                        choices=[
+                            ("available", "Available"),
+                            ("reserved", "Reserved"),
+                            ("unavailable", "Unavailable"),
+                            ("removed", "Removed"),
+                        ],
+                        default="unavailable",
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
-            name='EventRecord',
+            name="EventRecord",
             fields=[
-                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('saved_at', models.DateTimeField(db_index=True, default=django.utils.timezone.now)),
-                ('source', models.CharField(choices=[('push', 'push'), ('pull', 'pull')], default='push', max_length=16)),
-                ('event_type', mds.models.UnboundedCharField(choices=[('service_start', 'Service start'), ('trip_end', 'Trip end'), ('rebalance_drop_off', 'Rebalance drop_off'), ('maintenance_drop_off', 'Maintenance drop off'), ('cancel_reservation', 'Cancel reservation'), ('reserve', 'Reserve'), ('trip start', 'Trip start'), ('trip enter', 'Trip enter'), ('trip_leave', 'Trip leave'), ('register', 'Register'), ('low_battery', 'Low battery'), ('maintenance', 'Maintenance'), ('service_end', 'Service end'), ('rebalance_pick_up', 'Rebalance pick up'), ('maintenance_pick_up', 'Maintenance pick up'), ('deregister', 'Deregister'), ('telemetry', 'Received telemetry')])),
-                ('properties', django.contrib.postgres.fields.jsonb.JSONField(default=dict, encoder=rest_framework.utils.encoders.JSONEncoder)),
-                ('device', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='event_records', to='mds.Device')),
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "saved_at",
+                    models.DateTimeField(
+                        db_index=True, default=django.utils.timezone.now
+                    ),
+                ),
+                (
+                    "source",
+                    models.CharField(
+                        choices=[("push", "push"), ("pull", "pull")],
+                        default="push",
+                        max_length=16,
+                    ),
+                ),
+                (
+                    "event_type",
+                    mds.models.UnboundedCharField(
+                        choices=[
+                            ("service_start", "Service start"),
+                            ("trip_end", "Trip end"),
+                            ("rebalance_drop_off", "Rebalance drop_off"),
+                            ("maintenance_drop_off", "Maintenance drop off"),
+                            ("cancel_reservation", "Cancel reservation"),
+                            ("reserve", "Reserve"),
+                            ("trip_start", "Trip start"),
+                            ("trip_enter", "Trip enter"),
+                            ("trip_leave", "Trip leave"),
+                            ("register", "Register"),
+                            ("low_battery", "Low battery"),
+                            ("maintenance", "Maintenance"),
+                            ("service_end", "Service end"),
+                            ("rebalance_pick_up", "Rebalance pick up"),
+                            ("maintenance_pick_up", "Maintenance pick up"),
+                            ("deregister", "Deregister"),
+                            ("telemetry", "Received telemetry"),
+                        ]
+                    ),
+                ),
+                (
+                    "properties",
+                    django.contrib.postgres.fields.jsonb.JSONField(
+                        default=dict, encoder=rest_framework.utils.encoders.JSONEncoder
+                    ),
+                ),
+                (
+                    "device",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="event_records",
+                        to="mds.Device",
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
-            name='Polygon',
+            name="Polygon",
             fields=[
-                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
-                ('creation_date', models.DateTimeField(default=django.utils.timezone.now)),
-                ('deletion_date', models.DateTimeField(null=True)),
-                ('label', mds.models.UnboundedCharField(null=True)),
-                ('geom', django.contrib.gis.db.models.fields.PolygonField(srid=4326)),
-                ('properties', django.contrib.postgres.fields.jsonb.JSONField(default=dict, encoder=rest_framework.utils.encoders.JSONEncoder)),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, primary_key=True, serialize=False
+                    ),
+                ),
+                (
+                    "creation_date",
+                    models.DateTimeField(default=django.utils.timezone.now),
+                ),
+                ("deletion_date", models.DateTimeField(null=True)),
+                ("label", mds.models.UnboundedCharField(null=True)),
+                ("geom", django.contrib.gis.db.models.fields.PolygonField(srid=4326)),
+                (
+                    "properties",
+                    django.contrib.postgres.fields.jsonb.JSONField(
+                        default=dict, encoder=rest_framework.utils.encoders.JSONEncoder
+                    ),
+                ),
             ],
         ),
         migrations.CreateModel(
-            name='Provider',
+            name="Provider",
             fields=[
-                ('id', models.UUIDField(default=uuid.uuid4, primary_key=True, serialize=False)),
-                ('name', mds.models.UnboundedCharField(default=str)),
-                ('logo_b64', mds.models.UnboundedCharField(blank=True, default=None, null=True)),
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, primary_key=True, serialize=False
+                    ),
+                ),
+                ("name", mds.models.UnboundedCharField(default=str)),
+                (
+                    "logo_b64",
+                    mds.models.UnboundedCharField(blank=True, default=None, null=True),
+                ),
             ],
         ),
         migrations.AddField(
-            model_name='device',
-            name='provider',
-            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='devices', to='mds.Provider'),
+            model_name="device",
+            name="provider",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="devices",
+                to="mds.Provider",
+            ),
         ),
         migrations.AddField(
-            model_name='area',
-            name='polygons',
-            field=models.ManyToManyField(blank=True, related_name='areas', to='mds.Polygon'),
+            model_name="area",
+            name="polygons",
+            field=models.ManyToManyField(
+                blank=True, related_name="areas", to="mds.Polygon"
+            ),
         ),
         migrations.AddField(
-            model_name='area',
-            name='providers',
-            field=models.ManyToManyField(blank=True, related_name='areas', to='mds.Provider'),
+            model_name="area",
+            name="providers",
+            field=models.ManyToManyField(
+                blank=True, related_name="areas", to="mds.Provider"
+            ),
         ),
     ]

--- a/mds/models.py
+++ b/mds/models.py
@@ -74,10 +74,10 @@ class Device(models.Model):
     registration_date = models.DateTimeField(default=timezone.now)
     identification_number = UnboundedCharField()
 
-    category = UnboundedCharField(choices=enums.DEVICE_CATEGORY_CHOICES)
+    category = UnboundedCharField(choices=enums.choices(enums.DEVICE_CATEGORY))
     model = UnboundedCharField(default=str)
     propulsion = pg_fields.ArrayField(
-        UnboundedCharField(choices=enums.DEVICE_PROPULSION_CHOICES)
+        UnboundedCharField(choices=enums.choices(enums.DEVICE_PROPULSION))
     )
     year_manufactured = models.IntegerField(null=True)
     manufacturer = UnboundedCharField(default=str)
@@ -86,7 +86,7 @@ class Device(models.Model):
     dn_gps_point = gis_models.PointField(null=True)
     dn_gps_timestamp = models.DateTimeField(null=True)
     dn_status = UnboundedCharField(
-        choices=enums.DEVICE_STATUS_CHOICES, default="unavailable"
+        choices=enums.choices(enums.DEVICE_STATUS), default="unavailable"
     )
 
     objects = DeviceQueryset.as_manager()
@@ -108,12 +108,14 @@ class Device(models.Model):
 class EventRecord(models.Model):
     saved_at = models.DateTimeField(db_index=True, default=utils.timezone.now)
     source = models.CharField(
-        choices=enums.EVENT_INGESTION_SOURCES, default="push", max_length=16
+        choices=enums.choices(enums.EVENT_SOURCE),
+        default=enums.EVENT_SOURCE.push.name,
+        max_length=16,
     )
     device = models.ForeignKey(
         Device, related_name="event_records", on_delete=models.CASCADE
     )
-    event_type = UnboundedCharField(choices=enums.EVENT_TYPE_CHOICES)
+    event_type = UnboundedCharField(choices=enums.choices(enums.EVENT_TYPE))
 
     # JSON fields:
     # {

--- a/tests/apis/agency_api/v0_x/test_devices.py
+++ b/tests/apis/agency_api/v0_x/test_devices.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 
+from mds import enums
 from mds import factories
 from mds import models
 from mds.access_control.scopes import SCOPE_VEHICLE
@@ -137,7 +138,9 @@ def test_device_add(client):
 
     assert models.Device.objects.count() == 0
     # test auth
-    response = client.post("/mds/v0.x/vehicles/", data=data, content_type="application/json")
+    response = client.post(
+        "/mds/v0.x/vehicles/", data=data, content_type="application/json"
+    )
     assert response.status_code == 401
     response = client.post(
         "/mds/v0.x/vehicles/",
@@ -284,7 +287,7 @@ def test_device_telemetry(client, django_assert_num_queries):
         models.EventRecord.objects.filter(
             event_type="telemetry",
             device_id__in=[device_id % i for i in range(1, 4)],
-            source="push",
+            source=enums.EVENT_SOURCE.push.name,
         ).count()
         == 2
     )


### PR DESCRIPTION
Now in python 3 it is considered better style to use python enums,
and adapt them to Django or DRF  choices when necessary.
Also, added context to translations to avoid cumbersome rework in the future.