### PR TITLE
Refactor queryset to reuse latest_telemetry field

### DIFF
--- a/mds/management/commands/genfixture.py
+++ b/mds/management/commands/genfixture.py
@@ -7,7 +7,6 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         factories.Area(
-            label="District 10",
-            polygons=[factories.Polygon(), factories.Polygon()]
+            label="District 10", polygons=[factories.Polygon(), factories.Polygon()]
         )
         factories.Telemetry.create_batch(1000)

--- a/mds/models.py
+++ b/mds/models.py
@@ -7,6 +7,7 @@ from django import forms, utils
 from django.contrib.gis.db import models as gis_models
 from django.contrib.postgres import fields as pg_fields
 from django.db import models
+from django.db.models import OuterRef, Subquery, Prefetch
 from django.utils import timezone
 
 from rest_framework.utils import encoders
@@ -42,6 +43,24 @@ class Provider(models.Model):
     name = UnboundedCharField(default=str)
 
 
+class DeviceQueryset(models.QuerySet):
+
+    def with_latest_telemetry(self):
+        return self.prefetch_related(
+            Prefetch(
+                "telemetries",
+                queryset=Telemetry.objects.filter(
+                    id__in=Subquery(
+                        Telemetry.objects.filter(device_id=OuterRef("device_id"))
+                        .order_by("-timestamp")
+                        .values_list("id", flat=True)[:1]
+                    )
+                ),
+                to_attr="_latest_telemetry",
+            )
+        )
+
+
 class Device(models.Model):
     """A device
     """
@@ -56,6 +75,8 @@ class Device(models.Model):
     propulsion = UnboundedCharField(choices=enums.DEVICE_PROPULSION_CHOICES)
     registration_date = models.DateTimeField(default=timezone.now)
     properties = pg_fields.JSONField(default=dict, encoder=encoders.JSONEncoder)
+
+    objects = DeviceQueryset.as_manager()
 
     @property
     def latest_telemetry(self):
@@ -96,3 +117,8 @@ class Telemetry(models.Model):
 
     class Meta:
         verbose_name_plural = "telemetries"
+
+    @property
+    def point_as_geojson_list(self):
+        """Represent the point as the [longitude, latitute] GeoJSON convention."""
+        return [self.point.x, self.point.y]

--- a/mds/models.py
+++ b/mds/models.py
@@ -44,7 +44,6 @@ class Provider(models.Model):
 
 
 class DeviceQueryset(models.QuerySet):
-
     def with_latest_telemetry(self):
         return self.prefetch_related(
             Prefetch(


### PR DESCRIPTION
Now we can build a list of devices with telemetry in other contexts (ES export in my case).