### PR TITLE
setup: fix distutils.index-servers to `pypi`.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -68,3 +68,6 @@ python-tag = py3
 [zest.releaser]
 create-wheel = yes
 version-levels = 3
+
+[distutils]
+index-servers = pypi


### PR DESCRIPTION
This avoids zest upload on test or private indexes by default.