### PR TITLE
anticipate BlueLA serving a single associated trip

### DIFF
--- a/mds/factories.py
+++ b/mds/factories.py
@@ -706,7 +706,7 @@ class ProviderStatusChange(factory.DictFactory):
         }
     )
     battery_pct = 0.5
-    associated_trips = factory.List([])
+    associated_trip = None
 
 
 class ProviderStatusChangesBody(factory.DictFactory):

--- a/mds/management/commands/poll_providers.py
+++ b/mds/management/commands/poll_providers.py
@@ -113,7 +113,7 @@ class Command(management.BaseCommand):
                         point=geos.Point(event_location["geometry"]["coordinates"]),
                         event_type=event_type,
                         properties={
-                            "trip_id": None,  # XXX I receive a list
+                            "trip_id": status_change.get("associated_trip"),
                             "telemetry": {
                                 "timestamp": event_location["properties"]["timestamp"],
                                 "gps": {

--- a/mds/models.py
+++ b/mds/models.py
@@ -169,7 +169,7 @@ class EventRecord(models.Model):
 
     # JSON fields:
     # {
-    #   "telemetry": see serializers.PointProperties for the fields
+    #   "telemetry": see factories.EventRecord for an exhaustive example
     # }
     properties = pg_fields.JSONField(default=dict, encoder=encoders.JSONEncoder)
 


### PR DESCRIPTION
This is already merged in the MDS specs for the incoming 0.3.0 version.