### PR TITLE
apis: Fix UnixTimestampMilliseconds.to_representation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 0.5.1 (unreleased)
 ------------------
 
+- Fix conversion of datetime objects to MDS timestamps in the APIs.
 - Nothing changed yet.
 
 

--- a/mds/apis/utils.py
+++ b/mds/apis/utils.py
@@ -11,6 +11,9 @@ from rest_framework import status
 from rest_framework.exceptions import APIException
 from django.utils.translation import pgettext_lazy
 
+import mds.utils
+
+
 # Errors #######################################################
 
 
@@ -132,12 +135,10 @@ class PolygonSerializer(BaseGeometrySerializer):
 
 class UnixTimestampMilliseconds(serializers.IntegerField):
     def to_representation(self, value: datetime.datetime):
-        td = value - datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
-        return int(td.total_seconds() * 1000 + td.microseconds / 1000)
+        return mds.utils.to_mds_timestamp(value)
 
     def to_internal_value(self, value: int):
-        dt = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
-        return dt + datetime.timedelta(microseconds=value * 1000)
+        return mds.utils.from_mds_timestamp(value)
 
 
 # Schema #########################################################

--- a/mds/management/commands/poll_providers.py
+++ b/mds/management/commands/poll_providers.py
@@ -1,4 +1,3 @@
-import datetime
 import logging
 import traceback
 import urllib.parse
@@ -11,10 +10,10 @@ from django.db.models.aggregates import Max
 from oauthlib.oauth2 import BackendApplicationClient
 import requests
 from requests_oauthlib import OAuth2Session
-import pytz
 
 from mds import enums
 from mds import models
+from mds import utils
 
 
 NOT_PROVIDED = object()
@@ -60,7 +59,7 @@ class Command(management.BaseCommand):
             next_url = "%s?%s" % (
                 next_url,
                 urllib.parse.urlencode(
-                    {"start_time": int(max_timestamp.timestamp() * 1000)}
+                    {"start_time": utils.to_mds_timestamp(max_timestamp)}
                 ),
             )
 
@@ -94,9 +93,7 @@ class Command(management.BaseCommand):
                 # Filtering on start_time *should* be implemented
                 # So consider timestamps as unique per device
                 device.event_records.get_or_create(
-                    timestamp=datetime.datetime.fromtimestamp(
-                        status_change["event_time"] / 1000, pytz.utc
-                    ),
+                    timestamp=utils.from_mds_timestamp(status_change["event_time"]),
                     defaults=dict(
                         source="pull",  # pulled by agency
                         point=geos.Point(event_location["geometry"]["coordinates"]),

--- a/mds/utils.py
+++ b/mds/utils.py
@@ -1,0 +1,14 @@
+import datetime
+
+
+def to_mds_timestamp(dt: datetime.datetime) -> int:
+    """Convert a datetime object into an MDS-compliant timestamp.
+
+    MDS wants the timestamp to be in milliseconds.
+    """
+    return round(dt.timestamp() * 1000)
+
+
+def from_mds_timestamp(value: int) -> datetime:
+    """Convert an MDS timestamp (in milliseconds) to a datetime object."""
+    return datetime.datetime.fromtimestamp(value / 1000, tz=datetime.timezone.utc)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,29 @@
+import datetime
+
+from mds.apis import utils
+
+
+def test_unix_timestamp_milliseconds():
+    f = utils.UnixTimestampMilliseconds()
+
+    epoch = datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
+    assert f.to_representation(epoch) == 0
+    dt = epoch + datetime.timedelta(microseconds=1)
+    assert f.to_representation(dt) == 0
+    dt = epoch + datetime.timedelta(microseconds=999)
+    assert f.to_representation(dt) == 1
+    dt = epoch + datetime.timedelta(microseconds=1001)
+    assert f.to_representation(dt) == 1
+    dt = epoch + datetime.timedelta(microseconds=1000001)
+    assert f.to_representation(dt) == 1000
+    dt = epoch + datetime.timedelta(seconds=1, microseconds=1)
+    assert f.to_representation(dt) == 1000
+    dt = epoch + datetime.timedelta(seconds=1, microseconds=999)
+    assert f.to_representation(dt) == 1001
+
+    assert f.to_internal_value(0) == epoch
+    assert f.to_internal_value(1) == epoch + datetime.timedelta(microseconds=1000)
+    assert f.to_internal_value(1000) == epoch + datetime.timedelta(seconds=1)
+    assert f.to_internal_value(1001) == epoch + datetime.timedelta(
+        seconds=1, microseconds=1000
+    )


### PR DESCRIPTION
The implementation was wrong. `timedelta.total_seconds()` has
microsecond accuracy. Multiplied by 1000, we had a number of
milliseconds. But the implementation added `td.microseconds / 1000`,
which was wrong. A similarly correct implementation was:

    td = value - datetime.datetime(1970, 1, 1, tzinfo=datetime.timezone.utc)
    return round(td.total_seconds() * 1000)

... but `round(value.timestamp() * 1000)` is shorter.