### PR TITLE
Jchen/add areas to device serializer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 - Fix conversion of datetime objects to MDS timestamps in the APIs.
-- Added areas methodField to DeviceSerializer
+- Created separate RetrieveDeviceSerializer with areas methodField
 
 
 0.5.1 (2019-03-12)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 ------------------
 
 - Fix conversion of datetime objects to MDS timestamps in the APIs.
-- Nothing changed yet.
+- Added areas methodField to DeviceSerializer
 
 
 0.5.0 (2019-03-01)

--- a/mds/apis/prv_api/service_areas.py
+++ b/mds/apis/prv_api/service_areas.py
@@ -14,10 +14,7 @@ from mds.access_control.scopes import SCOPE_PRV_API
 from mds.apis import utils
 
 from rest_framework import filters
-<<<<<<< HEAD
 
-=======
->>>>>>> added alphabetical order for Polygon and Areas ViewSet
 
 class PolygonRequestSerializer(serializers.ModelSerializer):
     """What we expect for a geographic polygon.
@@ -79,13 +76,8 @@ class PolygonViewSet(utils.MultiSerializerViewSetMixin, viewsets.ModelViewSet):
     permission_classes = (require_scopes(SCOPE_PRV_API),)
     queryset = models.Polygon.objects.prefetch_related("areas").all()
     filter_backends = (filters.OrderingFilter,)
-<<<<<<< HEAD
     ordering_fields = ("label",)
     ordering = "label"
-=======
-    ordering_fields = ('label',)
-    ordering = ('label')
->>>>>>> added alphabetical order for Polygon and Areas ViewSet
     lookup_field = "id"
     serializer_class = PolygonResponseSerializer
     serializers_mapping = {
@@ -202,8 +194,8 @@ class AreaViewSet(utils.MultiSerializerViewSetMixin, viewsets.ModelViewSet):
     permission_classes = (require_scopes(SCOPE_PRV_API),)
     queryset = models.Area.objects.prefetch_related("polygons").all()
     filter_backends = (filters.OrderingFilter,)
-    ordering_fields = ('label',)
-    ordering = ('label')
+    ordering_fields = ("label",)
+    ordering = "label"
     lookup_field = "id"
     serializer_class = AreaResponseSerializer
     serializers_mapping = {

--- a/mds/apis/prv_api/service_areas.py
+++ b/mds/apis/prv_api/service_areas.py
@@ -14,7 +14,10 @@ from mds.access_control.scopes import SCOPE_PRV_API
 from mds.apis import utils
 
 from rest_framework import filters
+<<<<<<< HEAD
 
+=======
+>>>>>>> added alphabetical order for Polygon and Areas ViewSet
 
 class PolygonRequestSerializer(serializers.ModelSerializer):
     """What we expect for a geographic polygon.
@@ -76,8 +79,13 @@ class PolygonViewSet(utils.MultiSerializerViewSetMixin, viewsets.ModelViewSet):
     permission_classes = (require_scopes(SCOPE_PRV_API),)
     queryset = models.Polygon.objects.prefetch_related("areas").all()
     filter_backends = (filters.OrderingFilter,)
+<<<<<<< HEAD
     ordering_fields = ("label",)
     ordering = "label"
+=======
+    ordering_fields = ('label',)
+    ordering = ('label')
+>>>>>>> added alphabetical order for Polygon and Areas ViewSet
     lookup_field = "id"
     serializer_class = PolygonResponseSerializer
     serializers_mapping = {
@@ -194,8 +202,8 @@ class AreaViewSet(utils.MultiSerializerViewSetMixin, viewsets.ModelViewSet):
     permission_classes = (require_scopes(SCOPE_PRV_API),)
     queryset = models.Area.objects.prefetch_related("polygons").all()
     filter_backends = (filters.OrderingFilter,)
-    ordering_fields = ("label",)
-    ordering = "label"
+    ordering_fields = ('label',)
+    ordering = ('label')
     lookup_field = "id"
     serializer_class = AreaResponseSerializer
     serializers_mapping = {

--- a/mds/apis/prv_api/vehicles.py
+++ b/mds/apis/prv_api/vehicles.py
@@ -33,7 +33,7 @@ class DeviceFilter(filters.FilterSet):
         ]
 
 
-class DeviceSerializer(serializers.ModelSerializer):
+class BaseDeviceSerializer(serializers.ModelSerializer):
     id = serializers.UUIDField(help_text="Unique device identifier (UUID)")
     model = serializers.CharField(required=False, help_text="Vehicle model")
     identification_number = serializers.CharField(
@@ -70,15 +70,6 @@ class DeviceSerializer(serializers.ModelSerializer):
         help_text="Percentage between 0 and 1",
         allow_null=True,
     )
-    areas = serializers.SerializerMethodField()
-
-    def get_areas(self, obj):
-        if not obj.dn_gps_point:
-            return []
-        areas = models.Area.objects.filter(
-            polygons__geom__contains=obj.dn_gps_point
-        ).order_by("label", "id")
-        return list(areas.values("id", "label"))
 
     class Meta:
         model = models.Device
@@ -95,14 +86,31 @@ class DeviceSerializer(serializers.ModelSerializer):
             "registration_date",
             "last_telemetry_date",
             "battery",
-            "areas",
         )
 
 
-class DeviceViewSet(viewsets.ReadOnlyModelViewSet):
+class RetrieveDeviceSerializer(BaseDeviceSerializer):
+    areas = serializers.SerializerMethodField()
+
+    def get_areas(self, obj):
+        if not obj.dn_gps_point:
+            return []
+        areas = (
+            models.Area.objects.filter(polygons__geom__contains=obj.dn_gps_point)
+            .order_by("label", "id")
+            .distinct("label", "id")
+        )
+        return list(areas.values("id", "label"))
+
+    class Meta:
+        model = models.Device
+        fields = BaseDeviceSerializer.Meta.fields + ("areas",)
+
+
+class DeviceViewSet(utils.MultiSerializerViewSetMixin, viewsets.ReadOnlyModelViewSet):
     permission_classes = (require_scopes(SCOPE_PRV_API),)
     lookup_field = "id"
-    serializer_class = DeviceSerializer
+    serializer_class = BaseDeviceSerializer
     pagination_class = utils.LimitOffsetPagination
     filter_backends = (filters.DjangoFilterBackend,)
 
@@ -110,3 +118,7 @@ class DeviceViewSet(viewsets.ReadOnlyModelViewSet):
     queryset = (
         models.Device.objects.with_latest_event().select_related("provider").all()
     )
+    serializers_mapping = {
+        "list": {"response": BaseDeviceSerializer},
+        "retrieve": {"response": RetrieveDeviceSerializer},
+    }

--- a/mds/apis/prv_api/vehicles.py
+++ b/mds/apis/prv_api/vehicles.py
@@ -70,6 +70,15 @@ class DeviceSerializer(serializers.ModelSerializer):
         help_text="Percentage between 0 and 1",
         allow_null=True,
     )
+    areas = serializers.SerializerMethodField()
+
+    def get_areas(self, obj):
+        if not obj.dn_gps_point:
+            return []
+        areas = models.Area.objects.filter(
+            polygons__geom__contains=obj.dn_gps_point
+        ).order_by("label", "id")
+        return list(areas.values("id", "label"))
 
     class Meta:
         model = models.Device
@@ -86,6 +95,7 @@ class DeviceSerializer(serializers.ModelSerializer):
             "registration_date",
             "last_telemetry_date",
             "battery",
+            "areas",
         )
 
 

--- a/tests/apis/prv_api/test_vehicles.py
+++ b/tests/apis/prv_api/test_vehicles.py
@@ -63,6 +63,7 @@ def test_device_list_basic(client, django_assert_num_queries):
         "last_telemetry_date": "2012-01-01T00:00:00Z",
         "registration_date": "2012-01-01T00:00:00Z",
         "battery": 0.5,
+        "areas": [],
     }
     expected_device2 = {
         "id": uuid2,
@@ -77,6 +78,7 @@ def test_device_list_basic(client, django_assert_num_queries):
         "position": None,
         "registration_date": "2012-01-01T00:00:00Z",
         "battery": None,
+        "areas": [],
     }
     # test auth
     response = client.get("/prv/vehicles/")
@@ -84,6 +86,7 @@ def test_device_list_basic(client, django_assert_num_queries):
 
     n = BASE_NUM_QUERIES
     n += 1  # query on devices
+    n += 1  # query to get areas of device
     n += 1  # query latest events
     n += 1  # count on devices
     with django_assert_num_queries(n):
@@ -103,6 +106,7 @@ def test_device_list_basic(client, django_assert_num_queries):
 
     n = BASE_NUM_QUERIES
     n += 1  # query on devices
+    n += 1  # query to get areas of device
     n += 1  # query latest_event
     with django_assert_num_queries(n):
         response = client.get(

--- a/tests/apis/prv_api/test_vehicles.py
+++ b/tests/apis/prv_api/test_vehicles.py
@@ -19,6 +19,9 @@ def test_device_list_basic(client, django_assert_num_queries):
     provider = factories.Provider(name="Test provider")
     provider2 = factories.Provider(name="Test another provider")
 
+    area_id = "ccccccc3-1342-413b-8e89-db802b2f83f6"
+    area_label = "area_of_device1"
+
     device = factories.Device(
         id=uuid1,
         provider=provider,
@@ -63,7 +66,7 @@ def test_device_list_basic(client, django_assert_num_queries):
         "last_telemetry_date": "2012-01-01T00:00:00Z",
         "registration_date": "2012-01-01T00:00:00Z",
         "battery": 0.5,
-        "areas": [],
+        "areas": [{"id": uuid.UUID(area_id), "label": area_label}],
     }
     expected_device2 = {
         "id": uuid2,
@@ -80,6 +83,7 @@ def test_device_list_basic(client, django_assert_num_queries):
         "battery": None,
         "areas": [],
     }
+    factories.Area(id=area_id, label=area_label)
     # test auth
     response = client.get("/prv/vehicles/")
     assert response.status_code == 401

--- a/tests/apis/prv_api/test_vehicles.py
+++ b/tests/apis/prv_api/test_vehicles.py
@@ -19,9 +19,6 @@ def test_device_list_basic(client, django_assert_num_queries):
     provider = factories.Provider(name="Test provider")
     provider2 = factories.Provider(name="Test another provider")
 
-    area_id = "ccccccc3-1342-413b-8e89-db802b2f83f6"
-    area_label = "area_of_device1"
-
     device = factories.Device(
         id=uuid1,
         provider=provider,
@@ -66,7 +63,6 @@ def test_device_list_basic(client, django_assert_num_queries):
         "last_telemetry_date": "2012-01-01T00:00:00Z",
         "registration_date": "2012-01-01T00:00:00Z",
         "battery": 0.5,
-        "areas": [{"id": uuid.UUID(area_id), "label": area_label}],
     }
     expected_device2 = {
         "id": uuid2,
@@ -81,16 +77,13 @@ def test_device_list_basic(client, django_assert_num_queries):
         "position": None,
         "registration_date": "2012-01-01T00:00:00Z",
         "battery": None,
-        "areas": [],
     }
-    factories.Area(id=area_id, label=area_label)
     # test auth
     response = client.get("/prv/vehicles/")
     assert response.status_code == 401
 
     n = BASE_NUM_QUERIES
     n += 1  # query on devices
-    n += 1  # query to get areas of device
     n += 1  # query latest events
     n += 1  # count on devices
     with django_assert_num_queries(n):
@@ -112,6 +105,8 @@ def test_device_list_basic(client, django_assert_num_queries):
     n += 1  # query on devices
     n += 1  # query to get areas of device
     n += 1  # query latest_event
+    expected_device["areas"] = []
+
     with django_assert_num_queries(n):
         response = client.get(
             "/prv/vehicles/%s/" % device.id,


### PR DESCRIPTION
The purpose is to be able to retrieve the name of the areas in which the device is.