### PR TITLE
poll_providers: Don't raise an error if there is no status changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 0.5.3 (unreleased)
 ------------------
 
+- Gracefully handle absence of status changes in ``poll_providers`` command.
 - Fix conversion of datetime objects to MDS timestamps in the APIs.
 - Created separate RetrieveDeviceSerializer with areas methodField
 

--- a/mds/management/commands/poll_providers.py
+++ b/mds/management/commands/poll_providers.py
@@ -142,6 +142,8 @@ class Command(management.BaseCommand):
             # Translate older versions of data
             translated_data = translate_data(body["data"], body["version"])
             status_changes = translated_data["status_changes"]
+            if not status_changes:
+                break
 
             # A transaction for each "page" of data
             with transaction.atomic():


### PR DESCRIPTION
When there was no status changes, `process_status_changes()` would
raise an error when trying:

    max(status_change["event_time"] for status_change in status_changes)

... because `max` cannot be called on an empty sequence.