### PR TITLE
utils: single upsert command for creating event records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changelog
 0.5.12 (2019-04-05)
 -------------------
 
+- Move to an "upsert" pattern to write event pushing
 - Embed compiled translations in releases
 - Added new functionalities when listing on django admin site
 

--- a/mds/utils.py
+++ b/mds/utils.py
@@ -1,7 +1,11 @@
 import datetime
+import json
 import random
+import types
 
 from django.contrib.gis.geos.point import Point
+from django.db import connection
+from rest_framework.utils import encoders
 
 
 def to_mds_timestamp(dt: datetime.datetime) -> int:
@@ -25,3 +29,69 @@ def get_random_point(polygon):
         point = Point(random.uniform(x_min, x_max), random.uniform(y_min, y_max))
         if polygon.contains(point):
             return point
+
+
+def upsert_event_records(
+    event_records: types.GeneratorType, source: str, on_conflict_update=False
+):
+    """
+    Using "upsert" to create event or telemetry records.
+
+    Records pushed by providers have precedence over the ones we pull from them.
+    So we overwrite any existing record with the same timestamp for a given device.
+
+    Lines will be created or updated with the save time of the transaction.
+
+    Args:
+        event_records: list of EventRecord
+        source: "push" or "pull"
+        on_conflict_update: ignore duplicates (default) or overwrite
+    """
+
+    def serialize(event_record):
+        event_record.clean()
+        return {
+            "timestamp": event_record.timestamp,
+            "device_id": str(event_record.device_id),
+            "point": event_record.point.ewkt if event_record.point else None,
+            "event_type": event_record.event_type,
+            # The same encoder as in the model
+            "properties": json.dumps(event_record.properties, cls=encoders.JSONEncoder),
+            "source": source,
+        }
+
+    query = """
+        INSERT INTO mds_eventrecord (
+            device_id,
+            timestamp,
+            point,
+            event_type,
+            properties,
+            source,
+            saved_at
+        ) VALUES (
+            %(device_id)s,
+            %(timestamp)s,
+            %(point)s,
+            %(event_type)s,
+            %(properties)s,
+            %(source)s,
+            current_timestamp
+        )
+        """
+    if on_conflict_update:
+        query += """
+            ON CONFLICT (device_id, timestamp) DO UPDATE SET
+                point = EXCLUDED.point,
+                event_type = EXCLUDED.event_type,
+                properties = EXCLUDED.properties,
+                source = EXCLUDED.source,
+                saved_at = current_timestamp
+            """
+    else:
+        query += """
+            ON CONFLICT DO NOTHING
+            """
+
+    with connection.cursor() as cursor:
+        cursor.executemany(query, (serialize(record) for record in event_records))


### PR DESCRIPTION
The ones pushed by the provider have precedence.

The drawback over bulk_create is that we don't get the created objects in return.
