### PR TITLE
Fix slowness when retrieving device

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.5.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix the slowness when retrieving a device via private vehicle API
 
 
 0.5.9 (2019-03-28)

--- a/mds/apis/prv_api/vehicles.py
+++ b/mds/apis/prv_api/vehicles.py
@@ -68,9 +68,7 @@ class DeviceSerializer(serializers.ModelSerializer):
         allow_null=True,
     )
     battery = serializers.FloatField(
-        source="latest_event.properties.telemetry.battery_pct",
-        help_text="Percentage between 0 and 1",
-        allow_null=True,
+        source="dn_battery_pct", help_text="Percentage between 0 and 1", allow_null=True
     )
 
     class Meta:
@@ -121,9 +119,7 @@ class DeviceViewSet(utils.MultiSerializerViewSetMixin, viewsets.ReadOnlyModelVie
     filter_backends = (filters.DjangoFilterBackend,)
 
     filterset_class = DeviceFilter
-    queryset = (
-        models.Device.objects.with_latest_event().select_related("provider").all()
-    )
+    queryset = models.Device.objects.select_related("provider").all()
     serializers_mapping = {
         "list": {"response": DeviceSerializer},
         "retrieve": {"response": RetrieveDeviceSerializer},

--- a/tests/apis/prv_api/test_vehicles.py
+++ b/tests/apis/prv_api/test_vehicles.py
@@ -30,6 +30,7 @@ def test_device_list_basic(client, django_assert_num_queries):
         dn_status="available",
         dn_gps_point="Point(40 15.0)",
         dn_gps_timestamp=today,
+        dn_battery_pct=0.5,
     )
     factories.Device(
         id=uuid2,
@@ -42,6 +43,7 @@ def test_device_list_basic(client, django_assert_num_queries):
         dn_status="unavailable",
         dn_gps_point=None,
         dn_gps_timestamp=None,
+        dn_battery_pct=None,
     )
 
     # Add some telemetries on the first device
@@ -84,7 +86,6 @@ def test_device_list_basic(client, django_assert_num_queries):
 
     n = BASE_NUM_QUERIES
     n += 1  # query on devices
-    n += 1  # query latest events
     n += 1  # count on devices
     with django_assert_num_queries(n):
         response = client.get(
@@ -104,7 +105,6 @@ def test_device_list_basic(client, django_assert_num_queries):
     n = BASE_NUM_QUERIES
     n += 1  # query on devices
     n += 1  # query to get areas of device
-    n += 1  # query latest_event
     expected_device["areas"] = []
     expected_device["provider_logo"] = None
 


### PR DESCRIPTION
- use the dn value in device model rather than doing a query on latest event