### PR TITLE
Fix saving in base with wrong name for battery field in device telemetry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 - Fix the slowness when retrieving a device via private vehicle API
 - Fix with_latest_events query that is taking too much time, used in Agency API
+- Fix saving in base with the wrong name for the battery field in device Telemetry
 
 
 0.5.9 (2019-03-28)

--- a/mds/apis/agency_api/v0_x/vehicles.py
+++ b/mds/apis/agency_api/v0_x/vehicles.py
@@ -157,7 +157,7 @@ class DeviceTelemetrySerializer(serializers.Serializer):
     )
     charge = serializers.FloatField(
         required=False,
-        source="dn_battery_pct",
+        source="battery_pct",
         min_value=0,
         max_value=1,
         help_text="Percent battery charge of vehicle, expressed between 0 and 1",


### PR DESCRIPTION
- in the Device table, in properties dict field, and then in telemetry, the battery field name should have been "battery_pct"
- It was changed after, and now we have two conflicting namings in base. We have to fix that too