### PR TITLE
Fix translations which were not working

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.5.12 (unreleased)
 -------------------
 
-- Fix translations which none of them were working
+- Fix translations: none of them were working
 
 
 0.5.11 (2019-03-29)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.5.12 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix translations which none of them were working
 
 
 0.5.11 (2019-03-29)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.5.12 (unreleased)
 -------------------
 
-- Fix translations: none of them were working
+- Embed compiled translations in releases
 
 
 0.5.11 (2019-03-29)

--- a/prerelease_script.py
+++ b/prerelease_script.py
@@ -1,0 +1,8 @@
+import os
+
+def compilemessages(data):
+    if data['workingdir'] != data['reporoot']:
+        return
+    os.chdir("mds")
+    os.system("../manage.py compilemessages")
+

--- a/prerelease_script.py
+++ b/prerelease_script.py
@@ -1,8 +1,13 @@
 import os
 
-def compilemessages(data):
-    if data['workingdir'] != data['reporoot']:
-        return
-    os.chdir("mds")
-    os.system("../manage.py compilemessages")
 
+def compilemessages(data):
+    try:
+        if data['workingdir'] != data['reporoot']:
+            raise EnvironmentError('Working dir is not the root one')
+        os.chdir("mds")
+        os.system("../manage.py compilemessages")
+    except Exception as error:
+        print('Error occured while compilemessages')
+        print('Working Dir: ' + data['workingdir'])
+        print(error)

--- a/prerelease_script.py
+++ b/prerelease_script.py
@@ -1,13 +1,5 @@
-import os
+import subprocess
 
 
 def compilemessages(data):
-    try:
-        if data['workingdir'] != data['reporoot']:
-            raise EnvironmentError('Working dir is not the root one')
-        os.chdir("mds")
-        os.system("../manage.py compilemessages")
-    except Exception as error:
-        print('Error occured while compilemessages')
-        print('Working Dir: ' + data['workingdir'])
-        print(error)
+    subprocess.call(['django-admin', 'compilemessages'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -73,6 +73,8 @@ python-tag = py3
 [zest.releaser]
 create-wheel = yes
 version-levels = 3
+prereleaser.before =
+   prerelease_script.compilemessages
 
 [distutils]
 index-servers = pypi


### PR DESCRIPTION
- Translations were not working because no compilemessages command was ever run to generate the .mo files from the .po files