### PR TITLE
Add token authentication using browser url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.5.13 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add token authentication by specifying token in browser url
 
 
 0.5.12 (2019-04-05)

--- a/mds/access_control/stateless_jwt.py
+++ b/mds/access_control/stateless_jwt.py
@@ -29,7 +29,7 @@ class StatelessJwtAuthentication(BaseAuthentication):
         auth_header = get_authorization_header(request)
 
         if not auth_header:
-            return None
+            return request.GET.get("token", None)
 
         auth_header_prefix = "Bearer ".lower()
         auth = smart_text(auth_header)

--- a/mds/access_control/stateless_jwt.py
+++ b/mds/access_control/stateless_jwt.py
@@ -29,6 +29,8 @@ class StatelessJwtAuthentication(BaseAuthentication):
         auth_header = get_authorization_header(request)
 
         if not auth_header:
+            # only check on GET method
+            # for other methods such as POST, you would usually specify the header and the token in it
             return request.GET.get("token", None)
 
         auth_header_prefix = "Bearer ".lower()


### PR DESCRIPTION
I've tested it, and it seems to work.
- when I used the correct access_token, my export was working (it's working !)
- when using a wrong token, i was denied the access.