### PR TITLE
apis: complete router base names

### DIFF
--- a/mds/apis/agency_api/v0_x/urls.py
+++ b/mds/apis/agency_api/v0_x/urls.py
@@ -10,7 +10,9 @@ from . import vehicles
 
 
 agency_router = routers.DefaultRouter()
-agency_router.register(r"service_areas", service_areas.AreaViewSet)
+agency_router.register(
+    r"service_areas", service_areas.AreaViewSet, basename="service_area"
+)
 agency_router.register(r"vehicles", vehicles.DeviceViewSet, basename="device")
 
 

--- a/mds/apis/prv_api/urls.py
+++ b/mds/apis/prv_api/urls.py
@@ -15,9 +15,11 @@ def get_prv_router():
     been called on the router.
     """
     prv_router = routers.DefaultRouter()
-    prv_router.register(r"providers", providers.ProviderViewSet)
-    prv_router.register(r"service_areas", service_areas.AreaViewSet)
-    prv_router.register(r"polygons", service_areas.PolygonViewSet)
+    prv_router.register(r"providers", providers.ProviderViewSet, basename="provider")
+    prv_router.register(
+        r"service_areas", service_areas.AreaViewSet, basename="service_area"
+    )
+    prv_router.register(r"polygons", service_areas.PolygonViewSet, basename="polygon")
     prv_router.register(r"vehicles", vehicles.DeviceViewSet, basename="device")
     return prv_router
 


### PR DESCRIPTION
So I can write `reverse('prv_api:provider-list')` in tests.

It seems the convention, in the DRF router docstring too, is to use the
singular form.

I'll rant about the vehicle/device naming mess another time.