### PR TITLE
poll_providers: only update the field changed

### DIFF
--- a/mds/management/commands/poll_providers.py
+++ b/mds/management/commands/poll_providers.py
@@ -150,7 +150,7 @@ class Command(management.BaseCommand):
                     status_changes, provider
                 )
                 provider.last_start_time_polled = last_start_time_polled
-                provider.save(update_fields["last_start_time_polled"])
+                provider.save(update_fields=["last_start_time_polled"])
 
             next_url = body.get("links", {}).get("next")
 

--- a/mds/management/commands/poll_providers.py
+++ b/mds/management/commands/poll_providers.py
@@ -150,7 +150,7 @@ class Command(management.BaseCommand):
                     status_changes, provider
                 )
                 provider.last_start_time_polled = last_start_time_polled
-                provider.save()
+                provider.save(update_fields["last_start_time_polled"])
 
             next_url = body.get("links", {}).get("next")
 


### PR DESCRIPTION
I had a strange bug where my provider changes were not taken into
account, or quickly reverted to the old value.

It took me some time to realize the poller was running like crazy after
the full reset, and Django "save()" will dump the full state in memory
to the database.