### PR TITLE
prv_api: add a provider_api

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.5.15 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Add an aggregated "provider poll" endpoint (private and MDS 0.3.0 compliant).
 
 
 0.5.14 (2019-04-16)

--- a/mds/apis/prv_api/provider_api.py
+++ b/mds/apis/prv_api/provider_api.py
@@ -1,0 +1,99 @@
+from rest_framework import decorators, pagination, response, serializers, viewsets
+
+from mds import enums, models, utils
+from mds.access_control.permissions import require_scopes
+from mds.access_control.scopes import SCOPE_PRV_API
+from mds.apis import utils as apis_utils
+
+
+class DeviceStatusChangesSerializer(serializers.ModelSerializer):
+    associated_trip = serializers.CharField(source="properties.trip_id")
+    device_id = serializers.CharField(source="device.id")
+    event_location = serializers.SerializerMethodField()
+    event_time = apis_utils.UnixTimestampMilliseconds(source="timestamp")
+    event_type = serializers.SerializerMethodField()
+    event_type_reason = serializers.CharField(source="event_type")
+    propulsion_type = serializers.ListSerializer(
+        source="device.propulsion",
+        child=serializers.ChoiceField(choices=enums.choices(enums.DEVICE_PROPULSION)),
+    )
+    provider_id = serializers.CharField(source="device.provider.id")
+    provider_name = serializers.CharField(source="device.provider.name")
+    vehicle_id = serializers.CharField(source="device.identification_number")
+    vehicle_type = serializers.CharField(source="device.category")
+
+    class Meta:
+        model = models.EventRecord
+        fields = (
+            "associated_trip",
+            "device_id",
+            "event_location",
+            "event_time",
+            "event_type",
+            "event_type_reason",
+            "propulsion_type",
+            "provider_name",
+            "provider_id",
+            "vehicle_id",
+            "vehicle_type",
+        )
+
+    def create(self, data):
+        raise NotImplementedError()
+
+    def update(self, instance, data):
+        raise NotImplementedError()
+
+    def get_event_location(self, obj):
+        telemetry = obj.properties.get("telemetry", {})
+        return {
+            "type": "Feature",
+            "properties": {"timestamp": telemetry.get("timestamp")},
+            "geometry": obj.point_as_geojson,
+        }
+
+    def get_event_type(self, obj):
+        return enums.EVENT_TYPE_TO_DEVICE_STATUS[obj.event_type]
+
+
+class CustomPagination(pagination.PageNumberPagination):
+    page_size = 5000
+    page_size_query_param = "take"
+    max_page_size = 10000
+
+    def get_paginated_response(self, data):
+        return response.Response(
+            {
+                "version": "0.3.0",
+                "links": {
+                    "next": self.get_next_link(),
+                    "prev": self.get_previous_link(),
+                },
+                "data": {"status_changes": data},
+            }
+        )
+
+
+class ProviderApiViewSet(viewsets.ViewSet):
+    permission_classes = [require_scopes(SCOPE_PRV_API)]
+
+    @decorators.action(detail=False, methods=["get"])
+    def status_changes(self, request, *args, **kwargs):
+        start_time = request.query_params.get("start_time")
+        end_time = request.query_params.get("end_time")
+        # Only forward events that were first retrieved though providers'
+        # `status_changes' endpoint
+        event_types = enums.PROVIDER_EVENT_TYPE_REASON_TO_AGENCY_EVENT_TYPE.values()
+        events = models.EventRecord.objects.select_related("device__provider").filter(
+            event_type__in=event_types
+        )
+        if start_time:
+            start_time = utils.from_mds_timestamp(int(start_time))
+            events = events.filter(timestamp__gte=start_time)
+        if end_time:
+            end_time = utils.from_mds_timestamp(int(end_time))
+            events = events.filter(timestamp__lte=end_time)
+        paginator = CustomPagination()
+        page = paginator.paginate_queryset(events.order_by("timestamp"), request)
+        data = DeviceStatusChangesSerializer(page, many=True).data
+        return paginator.get_paginated_response(data)

--- a/mds/apis/prv_api/urls.py
+++ b/mds/apis/prv_api/urls.py
@@ -1,11 +1,8 @@
-from rest_framework import routers
 from django.conf.urls import include
 from django.urls import path
+from rest_framework import routers
 
-from . import providers
-from . import service_areas
-from . import vehicles
-from . import authent
+from . import authent, provider_api, providers, service_areas, vehicles
 
 
 def get_prv_router():
@@ -19,6 +16,9 @@ def get_prv_router():
     prv_router.register(r"service_areas", service_areas.AreaViewSet)
     prv_router.register(r"polygons", service_areas.PolygonViewSet)
     prv_router.register(r"vehicles", vehicles.DeviceViewSet, basename="device")
+    prv_router.register(
+        r"provider_api", provider_api.ProviderApiViewSet, basename="provider_api"
+    )
     return prv_router
 
 

--- a/tests/apis/prv_api/test_status_changes.py
+++ b/tests/apis/prv_api/test_status_changes.py
@@ -1,0 +1,145 @@
+import datetime
+
+import pytest
+from django.utils import timezone
+
+from mds import enums, factories, utils
+from mds.access_control.scopes import SCOPE_PRV_API
+from tests.auth_helpers import BASE_NUM_QUERIES, auth_header
+
+
+@pytest.mark.django_db
+def test_device_list_basic(client, django_assert_num_queries):
+    now = timezone.now()
+
+    uuid1 = "aaaaaaa1-1342-413b-8e89-db802b2f83f6"
+    uuid2 = "ccccccc3-1342-413b-8e89-db802b2f83f6"
+
+    provider = factories.Provider(name="Test provider")
+    provider2 = factories.Provider(name="Test another provider")
+
+    device1 = factories.Device(
+        id=uuid1,
+        provider=provider,
+        identification_number="1AAAAA",
+        model="Testa_Model_S",
+        category="car",
+        propulsion=["combustion"],
+        registration_date=now,
+        dn_status="available",
+        dn_gps_point="Point(40 15.0)",
+        dn_gps_timestamp=now,
+        dn_battery_pct=0.5,
+    )
+    device2 = factories.Device(
+        id=uuid2,
+        provider=provider2,
+        identification_number="3CCCCC",
+        model="Testa_Model_X",
+        category="scooter",
+        propulsion=["electric"],
+        registration_date=now,
+        dn_status="unavailable",
+        dn_gps_point=None,
+        dn_gps_timestamp=None,
+        dn_battery_pct=None,
+    )
+
+    # Add an event on the first device
+    factories.EventRecord(
+        device=device1,
+        timestamp=now,
+        event_type=enums.EVENT_TYPE.maintenance.name,
+        properties={
+            "trip_id": "b3da2d46-065f-4036-903c-49d796f09357",
+            "telemetry": {
+                "timestamp": 1_325_376_000_000,
+                "gps": {"lat": 33.996_339, "lng": -118.48153},
+            },
+        },
+    )
+    # A telemetry should not be considered as an event
+    factories.EventRecord(
+        device=device1,
+        timestamp=now - datetime.timedelta(seconds=1),
+        event_type=enums.EVENT_TYPE.telemetry.name,
+    )
+    # This one is too old
+    factories.EventRecord(device=device1, timestamp=now - datetime.timedelta(hours=1))
+
+    # Add an event on the second device
+    factories.EventRecord(
+        device=device2,
+        timestamp=now,
+        event_type=enums.EVENT_TYPE.trip_start.name,
+        properties={
+            "trip_id": None,
+            "telemetry": {
+                "timestamp": 1_325_376_000_000,
+                "gps": {"lat": 33.996_339, "lng": -118.48153},
+            },
+        },
+    )
+
+    expected_event_device1 = {
+        "provider_id": str(provider.id),
+        "provider_name": "Test provider",
+        "device_id": uuid1,
+        "vehicle_id": "1AAAAA",
+        "propulsion_type": ["combustion"],
+        "event_type_reason": "maintenance",
+        "event_type": "unavailable",
+        "vehicle_type": "car",
+        "event_time": utils.to_mds_timestamp(now),
+        "event_location": {
+            "type": "Feature",
+            "properties": {"timestamp": 1_325_376_000_000},
+            "geometry": {"type": "Point", "coordinates": [-118.48153, 33.996_339]},
+        },
+        "associated_trip": "b3da2d46-065f-4036-903c-49d796f09357",
+    }
+    expected_event_device2 = {
+        "provider_id": str(provider2.id),
+        "provider_name": "Test another provider",
+        "device_id": uuid2,
+        "vehicle_id": "3CCCCC",
+        "propulsion_type": ["electric"],
+        "event_type_reason": "trip_start",
+        "event_type": "trip",
+        "vehicle_type": "scooter",
+        "event_time": utils.to_mds_timestamp(now),
+        "event_location": {
+            "type": "Feature",
+            "properties": {"timestamp": 1_325_376_000_000},
+            "geometry": {"type": "Point", "coordinates": [-118.48153, 33.996_339]},
+        },
+        "associated_trip": None,
+    }
+    # test auth
+    response = client.get("/prv/provider_api/status_changes/")
+    assert response.status_code == 401
+
+    start_time = utils.to_mds_timestamp(now - datetime.timedelta(minutes=30))
+    n = BASE_NUM_QUERIES
+    n += 1  # query on events
+    n += 1  # count on events
+    with django_assert_num_queries(n):
+        response = client.get(
+            "/prv/provider_api/status_changes/?start_time=%s" % start_time,
+            **auth_header(SCOPE_PRV_API, provider_id=provider.id),
+        )
+    assert response.status_code == 200
+
+    data = response.data["data"]["status_changes"]
+    assert len(data) == 2
+
+    assert expected_event_device1 in data
+    assert expected_event_device2 in data
+
+    # Test pagination: retrieve only given number of events
+    response = client.get(
+        "/prv/provider_api/status_changes/?start_time=%s&take=1" % start_time,
+        **auth_header(SCOPE_PRV_API, provider_id=provider.id),
+    )
+    data = response.data["data"]["status_changes"]
+    assert len(data) == 1


### PR DESCRIPTION
Based on MDS provider API spec (https://github.com/CityOfLosAngeles/mobility-data-specification/tree/dev/provider)
expose an aggregated API (events from all providers).
This makes django-mds pluggable with external services that need
raw data.
For now only `status_change` endpoint is implemented.