### PR TITLE
pythhon dependencies: use non binary psycopg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ install_requires =
     djangorestframework
     drf-yasg
     getconf
-    psycopg2-binary
+    psycopg2
     pyjwt
     pyyaml
     requests_oauthlib


### PR DESCRIPTION
the binary version should not be required anymore @ 2.9.