### PR TITLE
prv_api: make DRF trailing slash optional

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.5.17 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Make trailing slash optional for private API urls.
 
 
 0.5.16 (2019-04-19)

--- a/mds/apis/prv_api/urls.py
+++ b/mds/apis/prv_api/urls.py
@@ -11,7 +11,7 @@ def get_prv_router():
     Enables to register new routes even after .urls has
     been called on the router.
     """
-    prv_router = routers.DefaultRouter()
+    prv_router = routers.DefaultRouter(trailing_slash="/?")
     prv_router.register(r"providers", providers.ProviderViewSet)
     prv_router.register(r"service_areas", service_areas.AreaViewSet)
     prv_router.register(r"polygons", service_areas.PolygonViewSet)


### PR DESCRIPTION
MDS spec does not enforce a trailing slash for "status_changes" endpoint.
We don't want either to forbid it.