### PR TITLE
For discussion: handle JSON Oauth2 authent along with urlencoded

### DIFF
--- a/mds/authent/oauthlib_utils.py
+++ b/mds/authent/oauthlib_utils.py
@@ -2,6 +2,7 @@ import datetime
 
 import oauthlib.oauth2
 import oauthlib.oauth2.rfc6749.tokens
+import oauth2_provider.oauth2_backends
 import oauth2_provider.models
 import oauth2_provider.oauth2_validators
 from oauth2_provider.scopes import BaseScopes
@@ -22,6 +23,16 @@ def signed_token_generator(request):
     # set claims on the request
     request.claims = payload
     return token
+
+
+class Backend(oauth2_provider.oauth2_backends.JSONOAuthLibCore):
+    def extract_body(self, request):
+        body = super().extract_body(request)
+        if not body:
+            body = oauth2_provider.oauth2_backends.OAuthLibCore.extract_body(
+                self, request
+            )
+        return body
 
 
 class Server(oauthlib.oauth2.Server):


### PR DESCRIPTION
There are two ways to retrieve a OAuth2 token (with our Django toolkit and in general AFAIK):
- The URI encoding we currently use:
https://github.com/jazzband/django-oauth-toolkit/blob/2fdb0fea4efec9bc79708f0ac1b4b24884f26f97/oauth2_provider/oauth2_backends.py#L74

- JSON in request body:
https://github.com/jazzband/django-oauth-toolkit/blob/2fdb0fea4efec9bc79708f0ac1b4b24884f26f97/oauth2_provider/oauth2_backends.py#L176

As we wrote a MDS indexer that uses the latter, it may be a useful addition, which could be nice for external services also (like providers).  

If we want to support both, it seems like we need our custom oauth2 backend and/or open a PR in django-auth-toolkit. 