### PR TITLE
provider_poller: limit initial polling

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 -------------------
 
 - Make trailing slash optional for private API urls.
+- Limit initial provider polling to a customizable number of days.
 
 
 0.5.16 (2019-04-19)

--- a/mds/provider_poller/poller.py
+++ b/mds/provider_poller/poller.py
@@ -21,6 +21,7 @@ from mds import models
 from mds import utils
 from .oauth2_store import OAuth2Store
 from .translation import translate_data
+from .settings import PROVIDER_POLLER_LIMIT_DAYS
 
 
 ACCEPTED_MDS_VERSIONS = ["0.2", "0.3"]
@@ -58,6 +59,11 @@ class StatusChangesPoller:
         if self.provider.last_start_time_polled:
             params["start_time"] = utils.to_mds_timestamp(
                 self.provider.last_start_time_polled
+            )
+        # Otherwise limit polling
+        elif PROVIDER_POLLER_LIMIT_DAYS:
+            params["start_time"] = utils.to_mds_timestamp(
+                timezone.now() - datetime.timedelta(PROVIDER_POLLER_LIMIT_DAYS)
             )
 
         # Provider-specific params to optimise polling

--- a/mds/provider_poller/settings.py
+++ b/mds/provider_poller/settings.py
@@ -1,0 +1,5 @@
+from django.conf import settings
+
+
+# May be set to None in order to pull all provider history
+PROVIDER_POLLER_LIMIT_DAYS = getattr(settings, "PROVIDER_POLLER_LIMIT", 90)


### PR DESCRIPTION
When first polling a provider, we usually don't want all
data from the dawn of times.
90 days is the default. Setting None is still an option to
retrieve everything.