### PR TITLE
poller: reuse the new settings module for defaults

### DIFF
--- a/mds/provider_poller/oauth2_store.py
+++ b/mds/provider_poller/oauth2_store.py
@@ -3,7 +3,6 @@ import logging
 import threading
 import urllib.parse
 
-from django.conf import settings
 from django.core.cache import caches
 
 from cryptography import fernet
@@ -11,22 +10,24 @@ from oauthlib.oauth2 import BackendApplicationClient
 from requests_oauthlib import OAuth2Session
 from retrying import retry
 
+from .settings import POLLER_TOKEN_CACHE, POLLER_TOKEN_ENCRYPTION_KEY
+
 
 CACHE_KEY_PATTERN = "mds:oauth2-token:%s"  # Provider ID added
 
-cache = caches[settings.POLLER_TOKEN_CACHE]
+cache = caches[POLLER_TOKEN_CACHE]
 
 logger = logging.getLogger(__name__)
 
 
 def _encrypt_token(token):
     encoded = json.dumps(token).encode("utf8")  # Fernet needs bytes
-    return fernet.Fernet(settings.POLLER_TOKEN_ENCRYPTION_KEY).encrypt(encoded)
+    return fernet.Fernet(POLLER_TOKEN_ENCRYPTION_KEY).encrypt(encoded)
 
 
 def _decrypt_token(encrypted):
     try:
-        encoded = fernet.Fernet(settings.POLLER_TOKEN_ENCRYPTION_KEY).decrypt(encrypted)
+        encoded = fernet.Fernet(POLLER_TOKEN_ENCRYPTION_KEY).decrypt(encrypted)
     except (fernet.InvalidToken, TypeError):  # The encryption key, not our token!
         return None
     else:

--- a/mds/provider_poller/settings.py
+++ b/mds/provider_poller/settings.py
@@ -1,5 +1,10 @@
 from django.conf import settings
 
+from cryptography import fernet
+
+
+POLLER_TOKEN_CACHE = getattr(settings, "POLLER_TOKEN_CACHE", "default")
+POLLER_TOKEN_ENCRYPTION_KEY = fernet.Fernet.generate_key()  # Reset on each restart
 
 # May be set to None in order to pull all provider history
 PROVIDER_POLLER_LIMIT_DAYS = getattr(settings, "PROVIDER_POLLER_LIMIT", 90)

--- a/mds/provider_poller/settings.py
+++ b/mds/provider_poller/settings.py
@@ -4,7 +4,11 @@ from cryptography import fernet
 
 
 POLLER_TOKEN_CACHE = getattr(settings, "POLLER_TOKEN_CACHE", "default")
-POLLER_TOKEN_ENCRYPTION_KEY = fernet.Fernet.generate_key()  # Reset on each restart
+POLLER_TOKEN_ENCRYPTION_KEY = getattr(
+    settings,
+    "POLLER_TOKEN_ENCRYPTION_KEY",
+    fernet.Fernet.generate_key(),  # The default is reset on each restart
+)
 
 # May be set to None in order to pull all provider history
 PROVIDER_POLLER_LIMIT_DAYS = getattr(settings, "PROVIDER_POLLER_LIMIT", 90)

--- a/mds/server/settings.py
+++ b/mds/server/settings.py
@@ -5,7 +5,6 @@ import itertools
 import os
 
 from corsheaders.defaults import default_headers
-from cryptography import fernet
 import getconf
 
 from mds.access_control.auth_means import (
@@ -149,7 +148,3 @@ MIGRATION_MODULES = {
     # ignore migrations and provide our own models.
     "oauth2_provider": None
 }
-
-# Poller configuration
-POLLER_TOKEN_CACHE = "default"
-POLLER_TOKEN_ENCRYPTION_KEY = fernet.Fernet.generate_key()  # Reset on each restart


### PR DESCRIPTION
Settings in the MDS server were of no help for projects hosting mds.

TODO: We're partly reinventing appconf here, check it out later.