### PR TITLE
prv_api: fix trailing slash option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 -------------------
 
 - Remove device_category after deprecation.
+- Fix private API optional trailing slash
 
 
 0.5.22 (2019-05-22)

--- a/mds/apis/prv_api/urls.py
+++ b/mds/apis/prv_api/urls.py
@@ -11,7 +11,8 @@ def get_prv_router():
     Enables to register new routes even after .urls has
     been called on the router.
     """
-    prv_router = routers.DefaultRouter(trailing_slash="/?")
+    prv_router = routers.DefaultRouter()
+    prv_router.trailing_slash = "/?"  # Make trailing slash optional
     prv_router.register(r"providers", providers.ProviderViewSet)
     prv_router.register(r"service_areas", service_areas.AreaViewSet)
     prv_router.register(r"polygons", service_areas.PolygonViewSet)

--- a/tests/apis/prv_api/test_status_changes.py
+++ b/tests/apis/prv_api/test_status_changes.py
@@ -116,7 +116,7 @@ def test_device_list_basic(client, django_assert_num_queries):
         "associated_trip": None,
     }
     # test auth
-    response = client.get("/prv/provider_api/status_changes/")
+    response = client.get("/prv/provider_api/status_changes")
     assert response.status_code == 401
 
     start_time = utils.to_mds_timestamp(now - datetime.timedelta(minutes=30))
@@ -125,7 +125,7 @@ def test_device_list_basic(client, django_assert_num_queries):
     n += 1  # count on events
     with django_assert_num_queries(n):
         response = client.get(
-            "/prv/provider_api/status_changes/?start_time=%s" % start_time,
+            "/prv/provider_api/status_changes?start_time=%s" % start_time,
             **auth_header(SCOPE_PRV_API, provider_id=provider.id),
         )
     assert response.status_code == 200
@@ -137,6 +137,14 @@ def test_device_list_basic(client, django_assert_num_queries):
     assert expected_event_device2 in data
 
     # Test pagination: retrieve only given number of events
+    response = client.get(
+        "/prv/provider_api/status_changes?start_time=%s&take=1" % start_time,
+        **auth_header(SCOPE_PRV_API, provider_id=provider.id),
+    )
+    data = response.data["data"]["status_changes"]
+    assert len(data) == 1
+
+    # Also test endpoint work with a trailing slash
     response = client.get(
         "/prv/provider_api/status_changes/?start_time=%s&take=1" % start_time,
         **auth_header(SCOPE_PRV_API, provider_id=provider.id),


### PR DESCRIPTION
commit 00ac141 was supposed to make trailing `/` optional
but a redirection was actually made when omitting it.
As DRF casts initial trailing_slash argument as a boolean
(https://github.com/encode/django-rest-framework/blob/afb678433b7dc068213e6e8a359ad1f6fff05b0d/rest_framework/routers.py#L148)
we need to set it as a regex after router initialization