### PR TITLE
Export (read only) event records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.5.31 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Read-only event records endpoint.
 
 
 0.5.30 (2019-06-20)

--- a/mds/apis/prv_api/event_records.py
+++ b/mds/apis/prv_api/event_records.py
@@ -1,0 +1,21 @@
+import django_filters.rest_framework
+from rest_framework import pagination, serializers, viewsets
+
+from mds.access_control import scopes
+from mds.access_control.permissions import require_scopes
+import mds.models
+
+
+class EventRecordSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = mds.models.EventRecord
+        fields = ["timestamp", "event_type"]
+
+
+class EventRecordViewSet(viewsets.ReadOnlyModelViewSet):
+    serializer_class = EventRecordSerializer
+    queryset = mds.models.EventRecord.objects.order_by("-timestamp")
+    pagination_class = pagination.LimitOffsetPagination
+    permission_classes = [require_scopes(scopes.SCOPE_PRV_API)]
+    filter_backends = (django_filters.rest_framework.DjangoFilterBackend,)
+    filterset_fields = ("device",)

--- a/mds/apis/prv_api/urls.py
+++ b/mds/apis/prv_api/urls.py
@@ -2,7 +2,7 @@ from django.conf.urls import include
 from django.urls import path
 from rest_framework import routers
 
-from . import authent, provider_api, providers, service_areas, vehicles
+from . import authent, provider_api, providers, service_areas, vehicles, event_records
 
 
 def get_prv_router():
@@ -19,6 +19,9 @@ def get_prv_router():
     prv_router.register(r"vehicles", vehicles.DeviceViewSet, basename="device")
     prv_router.register(
         r"provider_api", provider_api.ProviderApiViewSet, basename="provider_api"
+    )
+    prv_router.register(
+        r"event_records", event_records.EventRecordViewSet, basename="event_records"
     )
     return prv_router
 

--- a/mds/apis/schema.py
+++ b/mds/apis/schema.py
@@ -124,7 +124,10 @@ class CustomFilterInspector(FilterInspector):
             )
             extra_param["collection_format"] = "multi"
         else:
-            if isinstance(field, filters.ChoiceFilter):
+            if isinstance(field, filters.ModelChoiceFilter):
+                type_ = subtype = drf_yasg.openapi.TYPE_STRING
+                # extra_param?
+            elif isinstance(field, filters.ChoiceFilter):
                 type_ = subtype = drf_yasg.openapi.TYPE_STRING
                 extra_param["enum"] = [c for c, _ in field.extra["choices"]]
             elif isinstance(field, filters.NumberFilter):

--- a/tests/apis/prv_api/test_event_records.py
+++ b/tests/apis/prv_api/test_event_records.py
@@ -1,0 +1,28 @@
+import pytest
+
+from django.utils.dateparse import parse_datetime
+
+from mds import factories
+from mds.access_control.scopes import SCOPE_PRV_API
+from tests.auth_helpers import auth_header
+
+
+@pytest.mark.django_db
+def test_provider_basic(client, django_assert_num_queries):
+    device = factories.Device()
+    event_record = factories.EventRecord(device=device)
+    factories.EventRecord.create_batch(10)
+
+    response = client.get("/prv/event_records/")
+    assert response.status_code == 401
+
+    response = client.get("/prv/event_records/", **auth_header(SCOPE_PRV_API))
+    assert response.status_code == 200
+    assert len(response.data) == 11
+
+    response = client.get(
+        "/prv/event_records/", {"device": device.id}, **auth_header(SCOPE_PRV_API)
+    )
+    assert response.status_code == 200
+    assert len(response.data) == 1
+    assert parse_datetime(response.data[0]["timestamp"]) == event_record.timestamp


### PR DESCRIPTION
So we can get, e.g., the last 5 events on a given device.

Had to tell the schema generator a ModelChoiceFilter is not a
ChoiceFilter...