### PR TITLE
Fix crash on event record admin panel

### DIFF
--- a/mds/server/settings.py
+++ b/mds/server/settings.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     "corsheaders",
     "django.contrib.admin",
     "django.contrib.auth",
+    "django.contrib.gis",
     "django.contrib.contenttypes",
     "django.contrib.messages",
     "django.contrib.postgres",

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,8 +34,8 @@ install_requires =
     django-filter
     django-cors-headers
     django-oauth-toolkit
-    djangorestframework
-    drf-yasg
+    djangorestframework==3.9.3
+    drf-yasg==1.16.0
     getconf
     psycopg2
     pyjwt


### PR DESCRIPTION
When we go to the `Event Record` on the admin panel, we have a crash because of a missing template (postgis). Adding the application to fix this.

We fixed the versions of `djangorestframework==3.9.3` and `drf-yasg==1.16.0`, because there are still importing issues between the two due to the latest release of `djangorestframework (3.10.0)`.

This causes the error in this build: https://travis-ci.org/Polyconseil/django-mds/builds/562471386:

`
ImportError: Could not import 'drf_yasg.generators.OpenAPISchemaGenerator' for API setting 'DEFAULT_GENERATOR_CLASS'. ModuleNotFoundError: No module named 'packaging'.
`
