### PR TITLE
Allow providers polling to be overriden

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 -------------------
 
 - Allow to skip events in /status_changes endpoint .
-
+- Allow providers polling to be overidden.
 
 0.5.35 (2019-07-24)
 -------------------


### PR DESCRIPTION
This will enable to catch up some missed events in the past
with the `skip` query parameter.