### PR TITLE
Improvements on the EventRecord factory

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.5.38 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Improvements on the EventRecord factory to get more coherent Events
 
 
 0.5.37 (2019-07-31)

--- a/mds/factories.py
+++ b/mds/factories.py
@@ -6,7 +6,6 @@ import factory
 from django.contrib.gis import geos
 from django.contrib.gis.geos.geometry import GEOSGeometry
 from django.utils import timezone
-import pytz
 
 from . import models
 from . import enums
@@ -625,11 +624,9 @@ class EventRecord(factory.DjangoModelFactory):
     class Meta:
         model = models.EventRecord
 
-    id = factory.Sequence(str)
     device = factory.SubFactory(Device)
     timestamp = factory.Sequence(
-        lambda n: datetime.datetime(2018, 8, 1, tzinfo=pytz.utc)
-        + datetime.timedelta(seconds=n)
+        lambda n: timezone.now() - datetime.timedelta(minutes=n)
     )
     point = factory.LazyAttribute(
         lambda f: geos.Point(
@@ -637,7 +634,7 @@ class EventRecord(factory.DjangoModelFactory):
             f.properties["telemetry"]["gps"]["lat"],
         )
     )
-    saved_at = datetime.datetime(2018, 8, 1, 1, tzinfo=pytz.utc)
+    saved_at = factory.LazyAttribute(lambda f: f.timestamp)
     event_type = factory.Iterator(c.name for c in enums.EVENT_TYPE)
     properties = factory.Dict(
         {

--- a/tests/management/commands/test_poll_providers.py
+++ b/tests/management/commands/test_poll_providers.py
@@ -171,7 +171,7 @@ def test_follow_up(client):
                 provider.base_api_url,
                 "/status_changes?%s"
                 % urllib.parse.urlencode(
-                    {"start_time": int(event.timestamp.timestamp() * 1000)}
+                    {"start_time": round(event.timestamp.timestamp() * 1000)}
                 ),
             ),
             json=make_response(


### PR DESCRIPTION
The EventRecord factory may now generate Events with any id at anytime, with dates nearest to now.