### PR TITLE
Provider API: fix nullable trip_id crash

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.5.39 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Fix provider API crash when there is no trip_id.
 
 
 0.5.38 (2019-08-07)

--- a/mds/apis/prv_api/provider_api.py
+++ b/mds/apis/prv_api/provider_api.py
@@ -14,7 +14,7 @@ class DeviceStatusChangesSerializer(serializers.ModelSerializer):
     id = serializers.CharField()
     recorded = apis_utils.UnixTimestampMilliseconds(source="saved_at")
     first_recorded = apis_utils.UnixTimestampMilliseconds(source="first_saved_at")
-    associated_trip = serializers.CharField(source="properties.trip_id")
+    associated_trip = serializers.SerializerMethodField()
     device_id = serializers.CharField(source="device.id")
     event_location = serializers.SerializerMethodField()
     event_time = apis_utils.UnixTimestampMilliseconds(source="timestamp")
@@ -53,6 +53,9 @@ class DeviceStatusChangesSerializer(serializers.ModelSerializer):
 
     def update(self, instance, data):
         raise NotImplementedError()
+
+    def get_associated_trip(self, obj):
+        return obj.properties.get("trip_id", None)
 
     def get_event_location(self, obj):
         telemetry = obj.properties.get("telemetry", {})


### PR DESCRIPTION
When we receive a "register" event, there is no associated `trip_id`. It crashed. 