### PR TITLE
Provider API: only send 'provider' events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 -------------------
 
 - Fix provider API crash when there is no trip_id.
+- Fix filtering of provider API events (e.g. there should be no register event)
 
 
 0.5.38 (2019-08-07)

--- a/mds/apis/prv_api/provider_api.py
+++ b/mds/apis/prv_api/provider_api.py
@@ -104,10 +104,7 @@ class ProviderApiViewSet(viewsets.ViewSet):
 
         events = models.EventRecord.objects.select_related("device__provider").filter(
             # Only forward events that can be polled from a "provider API"
-            # Use the `provider -> agency` event mapping to exclude
-            # stored events (we cast to "agency" format) that are
-            # purely "agency" and have no "provider" equivalent
-            event_type__in=PROVIDER_REASON_TO_AGENCY_EVENT.values()
+            event_type__in=AGENCY_EVENT_TO_PROVIDER_REASON.keys()
         )
 
         # We support either recorded, time search or offset but not at the same time

--- a/mds/apis/prv_api/provider_api.py
+++ b/mds/apis/prv_api/provider_api.py
@@ -103,7 +103,7 @@ class ProviderApiViewSet(viewsets.ViewSet):
         end_time = request.query_params.get("end_time")
 
         events = models.EventRecord.objects.select_related("device__provider").filter(
-            # Only forward events that are can be polled from a "provider API"
+            # Only forward events that can be polled from a "provider API"
             # Use the `provider -> agency` event mapping to exclude
             # stored events (we cast to "agency" format) that are
             # purely "agency" and have no "provider" equivalent

--- a/mds/apis/prv_api/provider_api.py
+++ b/mds/apis/prv_api/provider_api.py
@@ -6,7 +6,6 @@ from mds.access_control.scopes import SCOPE_PRV_API
 from mds.apis import utils as apis_utils
 from mds.provider_mapping import (
     AGENCY_EVENT_TO_PROVIDER_REASON,
-    PROVIDER_REASON_TO_AGENCY_EVENT,
     PROVIDER_REASON_TO_PROVIDER_EVENT_TYPE,
 )
 

--- a/mds/apis/prv_api/provider_api.py
+++ b/mds/apis/prv_api/provider_api.py
@@ -6,6 +6,7 @@ from mds.access_control.scopes import SCOPE_PRV_API
 from mds.apis import utils as apis_utils
 from mds.provider_mapping import (
     AGENCY_EVENT_TO_PROVIDER_REASON,
+    PROVIDER_REASON_TO_AGENCY_EVENT,
     PROVIDER_REASON_TO_PROVIDER_EVENT_TYPE,
 )
 
@@ -102,8 +103,8 @@ class ProviderApiViewSet(viewsets.ViewSet):
         end_time = request.query_params.get("end_time")
 
         # Only forward events that are actual events and not telemetry
-        events = models.EventRecord.objects.select_related("device__provider").exclude(
-            event_type=enums.EVENT_TYPE.telemetry.name
+        events = models.EventRecord.objects.select_related("device__provider").filter(
+            event_type__in=PROVIDER_REASON_TO_AGENCY_EVENT.values()
         )
 
         # We support either recorded, time search or offset but not at the same time

--- a/mds/apis/prv_api/provider_api.py
+++ b/mds/apis/prv_api/provider_api.py
@@ -102,8 +102,11 @@ class ProviderApiViewSet(viewsets.ViewSet):
         start_time = request.query_params.get("start_time")
         end_time = request.query_params.get("end_time")
 
-        # Only forward events that are actual events and not telemetry
         events = models.EventRecord.objects.select_related("device__provider").filter(
+            # Only forward events that are can be polled from a "provider API"
+            # Use the `provider -> agency` event mapping to exclude
+            # stored events (we cast to "agency" format) that are
+            # purely "agency" and have no "provider" equivalent
             event_type__in=PROVIDER_REASON_TO_AGENCY_EVENT.values()
         )
 

--- a/tests/apis/prv_api/test_status_changes.py
+++ b/tests/apis/prv_api/test_status_changes.py
@@ -74,7 +74,7 @@ def status_changes_fixtures():
         device=device1,
         timestamp=now - datetime.timedelta(hours=1),
         saved_at=now - datetime.timedelta(hours=1),
-        event_type=enums.EVENT_TYPE.reserve.name,
+        event_type=enums.EVENT_TYPE.service_end.name,
     )
 
     # Add an event on the second device


### PR DESCRIPTION
`register` events were mistakenly sent by our side of the "provider API" following https://github.com/Polyconseil/django-mds/commit/7f30193c478ac75c8c3b739a380fda7c73181a4a. Because we can receive `register` events by providers that use the "agency API"