### PR TITLE
Better response 404

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 - Update Agency API ValidationError
+- Return device_id for 404 when device doesn't not exist
 
 
 0.6.0 (2019-09-02)

--- a/mds/apis/agency_api/v0_x/vehicles.py
+++ b/mds/apis/agency_api/v0_x/vehicles.py
@@ -334,7 +334,13 @@ class DeviceViewSet(
         provider_id = request.user.provider_id
         device = models.Device.objects.filter(provider_id=provider_id, id=id).last()
         if not device:
-            return Response(data={}, status=404)
+            return Response(
+                data={
+                    "message": f"No device found for device_id: {id}",
+                    "device_id": id,
+                },
+                status=404,
+            )
 
         provider = models.Provider.objects.get(pk=provider_id)
         request_serializer = self.get_serializer(


### PR DESCRIPTION
Goal: have the device_id in the error response when we push an event to a non-existant device.

```
{
    "message": "No device found for device_id: aaaaaaaa-7bbe-430f-8043-a799d4574000",
    "device_id": "aaaaaaaa-7bbe-430f-8043-a799d4574000"
}
```
