### PR TITLE
agency_api: fix results in random order

### DIFF
--- a/mds/apis/agency_api/v0_x/compliance.py
+++ b/mds/apis/agency_api/v0_x/compliance.py
@@ -51,7 +51,7 @@ class ComplianceSerializer(serializers.ModelSerializer):
 
 
 class ComplianceViewSet(viewsets.ModelViewSet):
-    queryset = models.Policy.objects
+    queryset = models.Policy.objects.order_by("start_date")
     serializer_class = ComplianceSerializer
 
     def get_queryset(self):

--- a/mds/factories.py
+++ b/mds/factories.py
@@ -1,6 +1,6 @@
 import datetime
-import zlib
 import random
+import zlib
 
 import factory
 


### PR DESCRIPTION
The matching test would be flaky as soon as another policy test took
precedence.