### PR TITLE
Add get_object_from_cache and use Settings to disable telemetry

### DIFF
--- a/mds/apis/agency_api/v0_x/vehicles.py
+++ b/mds/apis/agency_api/v0_x/vehicles.py
@@ -8,6 +8,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
+from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.db.utils import IntegrityError
 
@@ -16,9 +17,11 @@ from mds import enums, models, provider_mapping
 from mds.access_control.permissions import require_scopes
 from mds.access_control.scopes import SCOPE_AGENCY_API
 from mds.apis import utils as apis_utils
-from mds.utils import get_object_from_cache, telemetry_is_enabled
+from mds.utils import get_object_from_cache
 
 logger = logging.getLogger(__name__)
+
+telemetry_is_enabled = get_object_from_cache(settings.ENABLE_TELEMETRY_FUNCTION)
 
 
 class DeviceSerializer(serializers.Serializer):

--- a/mds/apis/agency_api/v0_x/vehicles.py
+++ b/mds/apis/agency_api/v0_x/vehicles.py
@@ -17,11 +17,11 @@ from mds import enums, models, provider_mapping
 from mds.access_control.permissions import require_scopes
 from mds.access_control.scopes import SCOPE_AGENCY_API
 from mds.apis import utils as apis_utils
-from mds.utils import get_object_from_cache
+from mds.utils import get_object_from_settings
 
 logger = logging.getLogger(__name__)
 
-telemetry_is_enabled = get_object_from_cache(settings.ENABLE_TELEMETRY_FUNCTION)
+is_telemetry_enabled = get_object_from_settings(settings.ENABLE_TELEMETRY_FUNCTION)
 
 
 class DeviceSerializer(serializers.Serializer):
@@ -390,7 +390,7 @@ class DeviceViewSet(
         context["provider"] = models.Provider.objects.get(pk=provider_id)
         serializer = self.get_serializer(data=request.data, context=context)
         serializer.is_valid(raise_exception=True)
-        instance = serializer.save() if telemetry_is_enabled() else None
+        instance = serializer.save() if is_telemetry_enabled() else None
         response_serializer = self.get_serializer(
             instance=instance, context={"request_or_response": "response"}
         )

--- a/mds/apis/agency_api/v0_x/vehicles.py
+++ b/mds/apis/agency_api/v0_x/vehicles.py
@@ -8,7 +8,6 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
 
-from django.conf import settings
 from django.contrib.gis.geos import Point
 from django.db.utils import IntegrityError
 
@@ -17,11 +16,9 @@ from mds import enums, models, provider_mapping
 from mds.access_control.permissions import require_scopes
 from mds.access_control.scopes import SCOPE_AGENCY_API
 from mds.apis import utils as apis_utils
-from mds.utils import get_object_from_settings
+from mds.utils import is_telemetry_enabled
 
 logger = logging.getLogger(__name__)
-
-is_telemetry_enabled = get_object_from_settings(settings.ENABLE_TELEMETRY_FUNCTION)
 
 
 class DeviceSerializer(serializers.Serializer):

--- a/mds/apis/agency_api/v0_x/vehicles.py
+++ b/mds/apis/agency_api/v0_x/vehicles.py
@@ -16,6 +16,7 @@ from mds import enums, models, provider_mapping
 from mds.access_control.permissions import require_scopes
 from mds.access_control.scopes import SCOPE_AGENCY_API
 from mds.apis import utils as apis_utils
+from mds.utils import get_object_from_cache, telemetry_is_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -386,7 +387,7 @@ class DeviceViewSet(
         context["provider"] = models.Provider.objects.get(pk=provider_id)
         serializer = self.get_serializer(data=request.data, context=context)
         serializer.is_valid(raise_exception=True)
-        instance = serializer.save()
+        instance = serializer.save() if telemetry_is_enabled() else None
         response_serializer = self.get_serializer(
             instance=instance, context={"request_or_response": "response"}
         )

--- a/mds/server/settings.py
+++ b/mds/server/settings.py
@@ -24,6 +24,10 @@ ALLOWED_HOSTS = CONFIG.getlist(
     "django.allowed_hosts", [], doc="Comma-separated list of allowed hosts"
 )
 
+
+ENABLE_TELEMETRY_FUNCTION = "mds.utils.telemetry_enabled"
+
+
 INSTALLED_APPS = [
     "mds.authent.apps.Config",
     "mds.authent.oauth2_provider_apps.Config",

--- a/mds/server/settings.py
+++ b/mds/server/settings.py
@@ -25,7 +25,7 @@ ALLOWED_HOSTS = CONFIG.getlist(
 )
 
 
-ENABLE_TELEMETRY_FUNCTION = "mds.utils.telemetry_enabled"
+ENABLE_TELEMETRY_FUNCTION = "mds.utils.telemetry_is_enabled"
 
 
 INSTALLED_APPS = [

--- a/mds/utils.py
+++ b/mds/utils.py
@@ -1,7 +1,27 @@
 import datetime
+import importlib
 import random
 
+from django.conf import settings
 from django.contrib.gis.geos.point import Point
+
+from functools import lru_cache
+
+
+@lru_cache(maxsize=128)
+def get_object_from_cache(setting):
+    """Return an object.
+
+    ``setting`` should be a full Python path,
+    e.g. ``subzero.core.processes.customer.CustomerProcess``.
+    """
+    module_name, obj_name = setting.rsplit(".", 1)
+    module = importlib.import_module(module_name)
+    object = getattr(module, obj_name)
+    return object
+
+
+telemetry_is_enabled = get_object_from_cache(settings.ENABLE_TELEMETRY_FUNCTION)
 
 
 def to_mds_timestamp(dt: datetime.datetime) -> int:

--- a/mds/utils.py
+++ b/mds/utils.py
@@ -2,7 +2,6 @@ import datetime
 import importlib
 import random
 
-from django.conf import settings
 from django.contrib.gis.geos.point import Point
 
 from functools import lru_cache
@@ -21,7 +20,14 @@ def get_object_from_cache(setting):
     return object
 
 
-telemetry_is_enabled = get_object_from_cache(settings.ENABLE_TELEMETRY_FUNCTION)
+def telemetry_enabled():
+    """
+    This function is imported with `get_object_from_cache`
+    from ENABLE_TELEMETRY_FUNCTION in the settings.
+    It may easily be overriden to enable/disable the telemetries
+    saving from a setting.
+    """
+    return True
 
 
 def to_mds_timestamp(dt: datetime.datetime) -> int:

--- a/mds/utils.py
+++ b/mds/utils.py
@@ -2,6 +2,7 @@ import datetime
 import importlib
 import random
 
+from django.conf import settings
 from django.contrib.gis.geos.point import Point
 
 from functools import lru_cache
@@ -27,6 +28,9 @@ def telemetry_is_enabled():
     saving through a dynamic setting.
     """
     return True
+
+
+is_telemetry_enabled = get_object_from_settings(settings.ENABLE_TELEMETRY_FUNCTION)
 
 
 def to_mds_timestamp(dt: datetime.datetime) -> int:

--- a/mds/utils.py
+++ b/mds/utils.py
@@ -7,25 +7,24 @@ from django.contrib.gis.geos.point import Point
 from functools import lru_cache
 
 
-@lru_cache(maxsize=128)
-def get_object_from_cache(setting):
+@lru_cache()
+def get_object_from_settings(setting):
     """Return an object.
 
     ``setting`` should be a full Python path,
-    e.g. ``subzero.core.processes.customer.CustomerProcess``.
+    e.g. ``mds.utils.telemetry_is_enabled``.
     """
     module_name, obj_name = setting.rsplit(".", 1)
     module = importlib.import_module(module_name)
-    object = getattr(module, obj_name)
-    return object
+    return getattr(module, obj_name)
 
 
-def telemetry_enabled():
+def telemetry_is_enabled():
     """
     This function is imported with `get_object_from_cache`
     from ENABLE_TELEMETRY_FUNCTION in the settings.
     It may easily be overriden to enable/disable the telemetries
-    saving from a setting.
+    saving through a dynamic setting.
     """
     return True
 

--- a/tests/apis/agency_api/v0_x/test_devices.py
+++ b/tests/apis/agency_api/v0_x/test_devices.py
@@ -390,12 +390,14 @@ def test_device_telemetry(client, django_assert_num_queries):
     )
 
 
-def returnFalse():
+def return_false():
     return False
 
 
 @pytest.mark.django_db
-@override_settings(ENABLE_TELEMETRY_FUNCTION="tests.apis.agency_api.v0_x.test_devices.returnFalse")
+@override_settings(
+    ENABLE_TELEMETRY_FUNCTION="tests.apis.agency_api.v0_x.test_devices.return_false"
+)
 def test_device_telemetry_when_disabled(client, django_assert_num_queries):
     mds.apis.agency_api.v0_x.vehicles.is_telemetry_enabled = lambda: False
 

--- a/tests/apis/agency_api/v0_x/test_devices.py
+++ b/tests/apis/agency_api/v0_x/test_devices.py
@@ -12,6 +12,9 @@ from mds.access_control.scopes import SCOPE_AGENCY_API
 from tests.auth_helpers import auth_header, BASE_NUM_QUERIES
 
 
+import mds.apis.agency_api.v0_x.vehicles
+
+
 @pytest.mark.django_db
 def test_devices_metadata(client):
     provider = factories.Provider(name="Test provider")
@@ -388,9 +391,7 @@ def test_device_telemetry(client, django_assert_num_queries):
 
 @pytest.mark.django_db
 def test_device_telemetry_when_disabled(client, django_assert_num_queries):
-    import mds.apis.agency_api.v0_x.vehicles
-
-    mds.apis.agency_api.v0_x.vehicles.telemetry_is_enabled = lambda: False
+    mds.apis.agency_api.v0_x.vehicles.is_telemetry_enabled = lambda: False
 
     provider = factories.Provider(id=uuid.UUID("aaaa0000-61fd-4cce-8113-81af1de90942"))
     provider2 = factories.Provider(id=uuid.UUID("aaaa0000-61fd-4cce-8113-81af1de90943"))


### PR DESCRIPTION
This PR creates a settings and a function that'll need to be overriden to disable the registration of telemetries.