### PR TITLE
Only run one CI for Pull Requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ addons:
         - postgresql-10-postgis-2.4
 python:
     - "3.7"
+branches:
+  only:
+    - master
 install:
     - "pip install -e .[dev]"
 before_script:


### PR DESCRIPTION
Make travis CI only launch one test run on Pull Request
- branch checks will only be run on master
- PR checks are left unchanged