### PR TITLE
enums: simpler naming of policy types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.6.23 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- Simpler enumeration of policy types.
 
 
 0.6.22 (2019-12-17)

--- a/mds/enums.py
+++ b/mds/enums.py
@@ -173,30 +173,9 @@ POLICY_RULE_TYPES = enum.Enum(
     "Policy types",
     [
         ("count", pgettext_lazy("Policy type", "Fleet size")),
-        (
-            "time",
-            pgettext_lazy(
-                "Policy type",
-                "Individual limitations on time spent in one or more vehicle-states. "
-                "Rule max/min refers to number of minutes.",
-            ),
-        ),
-        (
-            "speed",
-            pgettext_lazy(
-                "Policy type",
-                "Global or local speed limits. "
-                "Rule max/min refers to miles per hour.",
-            ),
-        ),
-        (
-            "user",
-            pgettext_lazy(
-                "Policy type",
-                "Information for users, e.g. about helmet laws. "
-                "Generally can't be enforced via events and telemetry.",
-            ),
-        ),
+        ("time", pgettext_lazy("Policy type", "Time limit")),
+        ("speed", pgettext_lazy("Policy type", "Speed limit")),
+        ("user", pgettext_lazy("Policy type", "Information for users")),
         ("geofence", pgettext_lazy("Policy type", "Geofencing")),
     ],
 )

--- a/mds/locale/en_US/LC_MESSAGES/django.po
+++ b/mds/locale/en_US/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-15 13:43+0200\n"
+"POT-Creation-Date: 2019-12-17 15:45+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: en_US\n"
@@ -325,26 +325,22 @@ msgctxt "Policy type"
 msgid "Fleet size"
 msgstr ""
 
-#: enums.py:180
+#: enums.py:176
 msgctxt "Policy type"
-msgid ""
-"Individual limitations on time spent in one or more vehicle-states. Rule max/"
-"min refers to number of minutes."
+msgid "Time limit"
 msgstr ""
 
-#: enums.py:188
+#: enums.py:177
 msgctxt "Policy type"
-msgid "Global or local speed limits. Rule max/min refers to miles per hour."
+msgid "Speed limit"
 msgstr ""
 
-#: enums.py:196
+#: enums.py:178
 msgctxt "Policy type"
-msgid ""
-"Information for users, e.g. about helmet laws. Generally can't be enforced "
-"via events and telemetry."
+msgid "Information for users"
 msgstr ""
 
-#: enums.py:200
+#: enums.py:179
 msgctxt "Policy type"
 msgid "Geofencing"
 msgstr ""

--- a/mds/locale/fr_FR/LC_MESSAGES/django.po
+++ b/mds/locale/fr_FR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-10-15 13:43+0200\n"
+"POT-Creation-Date: 2019-12-17 15:45+0100\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: fr_FR\n"
@@ -358,38 +358,24 @@ msgctxt "Policy type"
 msgid "Fleet size"
 msgstr "Taille de flotte"
 
-#: enums.py:180
+#: enums.py:176
+#| msgctxt "Policy type"
+#| msgid "Speed limit"
 msgctxt "Policy type"
-msgid ""
-"Individual limitations on time spent in one or more vehicle-states. Rule max/"
-"min refers to number of minutes."
-msgstr ""
-"Limites individuelles concernant le temps écoulé dans un ou plusieurs états-"
-"véhicule. La règle max/min fait référence au nombre de minutes."
+msgid "Time limit"
+msgstr "Limite de temps"
 
-#: enums.py:188
+#: enums.py:177
 msgctxt "Policy type"
-msgid "Global or local speed limits. Rule max/min refers to miles per hour."
-msgstr ""
-"Limites de vitesse globales ou locales. La règle max/min fait références à "
-"miles par heure."
+msgid "Speed limit"
+msgstr "Limite de vitesse"
 
-#: enums.py:196
+#: enums.py:178
 msgctxt "Policy type"
-msgid ""
-"Information for users, e.g. about helmet laws. Generally can't be enforced "
-"via events and telemetry."
-msgstr ""
-"Information pour les utlisateurs, ex: sur les lois de port du casque. En "
-"général cela ne peut être imposé via des événements et la télémétrie."
+msgid "Information for users"
+msgstr "Information aux utilisateurs"
 
-#: enums.py:200
+#: enums.py:179
 msgctxt "Policy type"
 msgid "Geofencing"
 msgstr "Zone interdite"
-
-#~ msgid "No application known for owner %s"
-#~ msgstr "Pas d'application connue pour %s"
-
-#~ msgid "No access token known for %s"
-#~ msgstr "Pas de jeton d'accès pour %s"


### PR DESCRIPTION
Those long explanations are better suited in a policy help text or
description.

And it seems like the locales haven't been updated in a long time...
You have to run "django-admin makemessages" from within the "mds"
folder.