### PR TITLE
poller: deactivate fake register events by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Don't create register events on the fly in the poller.
 
 
 0.7.0 (2019-12-18)

--- a/mds/enums.py
+++ b/mds/enums.py
@@ -35,7 +35,7 @@ class DEVICE_PROPULSION(enum.Enum):
 
 class EVENT_TYPE(enum.Enum):
     # The first events are the one listed in the MDS agency API, in order:
-    # https://github.com/CityOfLosAngeles/mobility-data-specification/tree/dev/agency
+    # https://github.com/openmobilityfoundation/mobility-data-specification/tree/dev/agency#vehicle-events
     register = pgettext_lazy("Event type", "Register")
     service_start = pgettext_lazy("Event type", "Service start")
     service_end = pgettext_lazy("Event type", "Service end")

--- a/mds/provider_poller/poller.py
+++ b/mds/provider_poller/poller.py
@@ -24,6 +24,7 @@ from mds.provider_mapping import PROVIDER_REASON_TO_AGENCY_EVENT
 from .oauth2_store import OAuth2Store
 from .translation import translate_data
 from .settings import PROVIDER_POLLER_LIMIT_DAYS
+from .settings import POLLER_CREATE_REGISTER_EVENTS
 
 
 ACCEPTED_MDS_VERSIONS = ["0.2", "0.3"]
@@ -383,14 +384,15 @@ class StatusChangesPoller:
                     for status_change in with_missing_devices
                 )
             )
-            # Create fake register events to simulate device registration
-            db_helpers.upsert_event_records(
-                (
-                    _create_register_event_record(status_change)
-                    for status_change in with_missing_devices
-                ),
-                source=enums.EVENT_SOURCE.provider_api.name,
-            )
+            if POLLER_CREATE_REGISTER_EVENTS:
+                # Create fake register events to simulate device registration
+                db_helpers.upsert_event_records(
+                    (
+                        _create_register_event_record(status_change)
+                        for status_change in with_missing_devices
+                    ),
+                    source=enums.EVENT_SOURCE.provider_api.name,
+                )
 
             devices_added = [
                 status_change["device_id"] for status_change in with_missing_devices

--- a/mds/provider_poller/settings.py
+++ b/mds/provider_poller/settings.py
@@ -10,5 +10,9 @@ POLLER_TOKEN_ENCRYPTION_KEY = getattr(
     fernet.Fernet.generate_key(),  # The default is reset on each restart
 )
 
+POLLER_CREATE_REGISTER_EVENTS = getattr(
+    settings, "POLLER_CREATE_REGISTER_EVENTS", False
+)
+
 # May be set to None in order to pull all provider history
 PROVIDER_POLLER_LIMIT_DAYS = getattr(settings, "PROVIDER_POLLER_LIMIT", 90)

--- a/tests/management/commands/test_poll_providers.py
+++ b/tests/management/commands/test_poll_providers.py
@@ -19,8 +19,9 @@ from mds.provider_mapping import (
 
 
 @pytest.mark.django_db
-def test_poll_provider_batch(client):
+def test_poll_provider_batch(client, settings):
     """A single provider with two pages of status changes."""
+    settings.POLLER_CREATE_REGISTER_EVENTS = True
     provider = factories.Provider()
     # The first device received already exists
     device1 = factories.Device(provider=provider)
@@ -78,8 +79,9 @@ def test_poll_provider_batch(client):
 
 
 @pytest.mark.django_db
-def test_several_providers(client, django_assert_num_queries):
+def test_several_providers(client, django_assert_num_queries, settings):
     """Two providers this time."""
+    settings.POLLER_CREATE_REGISTER_EVENTS = True
     provider1 = factories.Provider(base_api_url="http://provider1")
     device1 = factories.Device.build(provider=provider1)
     expected_event1 = factories.EventRecord.build(
@@ -137,8 +139,9 @@ def test_several_providers(client, django_assert_num_queries):
 
 
 @pytest.mark.django_db
-def test_follow_up(client):
+def test_follow_up(client, settings):
     """Catching up new telemetries from the last one we got."""
+    settings.POLLER_CREATE_REGISTER_EVENTS = True
     event = factories.EventRecord()
     device = event.device
     provider = device.provider


### PR DESCRIPTION
Closes: SMP-1362

If proven useless, remove them altogether.