### PR TITLE
provider_poller: restore the expected behaviour for 0.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.7.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Hotfix: we broke 0.4 servers too strict on the MDS spec.
 
 
 0.7.5 (2020-01-14)

--- a/mds/provider_poller/poller.py
+++ b/mds/provider_poller/poller.py
@@ -460,14 +460,17 @@ class StatusChangesPoller:
         else:
             raise NotImplementedError
 
-        headers = {
+        headers = {}
+
+        # TODO(hcauwelier) just fork the code for MDS 0.4
+        if api_version == "0.4":
             # We only accept the version we expect from that provider
             # And it should reject it when it bumps to the new version
+            headers["Accept"] = "%s;version=%s" % (MDS_CONTENT_TYPE, api_version)
+        else:
             # TODO(hcauwelier) some server implementations are flawed
             # leave the standard content type for now
-            "Accept": "application/json,%s;version=%s"
-            % (MDS_CONTENT_TYPE, api_version)
-        }
+            headers["Accept"] = "application/json,%s;version=%s" % (MDS_CONTENT_TYPE, api_version)
 
         logger.debug("Polling provider on URL %s with headers %s", url, headers)
         response = client.get(url, timeout=30, headers=headers)

--- a/mds/provider_poller/poller.py
+++ b/mds/provider_poller/poller.py
@@ -470,7 +470,10 @@ class StatusChangesPoller:
         else:
             # TODO(hcauwelier) some server implementations are flawed
             # leave the standard content type for now
-            headers["Accept"] = "application/json,%s;version=%s" % (MDS_CONTENT_TYPE, api_version)
+            headers["Accept"] = "application/json,%s;version=%s" % (
+                MDS_CONTENT_TYPE,
+                api_version,
+            )
 
         logger.debug("Polling provider on URL %s with headers %s", url, headers)
         response = client.get(url, timeout=30, headers=headers)


### PR DESCRIPTION
I think a MDS 0.4 server rejecting "application/json" is too strict, the
HTTP standard allows for multiple Accept values, the server just chooses
the first one that matches.