### PR TITLE
API Agency: autoriser le register de vehicles sur /vehicles, /event et /telemetry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 0.7.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix trailing slash in Agency api v0.3
 
 
 0.7.7 (2020-01-14)

--- a/mds/apis/agency_api/v0_3/urls.py
+++ b/mds/apis/agency_api/v0_3/urls.py
@@ -15,6 +15,8 @@ from . import compliances
 
 
 agency_router = routers.DefaultRouter()
+agency_router.trailing_slash = "/?"  # Make trailing slash optional
+
 agency_router.register(r"vehicles", vehicles.DeviceViewSet, basename="device")
 agency_router.register(r"policies", policies.PolicyViewSet, basename="policy")
 agency_router.register(

--- a/tests/apis/agency_api/v0_3/test_devices.py
+++ b/tests/apis/agency_api/v0_3/test_devices.py
@@ -147,6 +147,10 @@ def test_device_list_basic(client, django_assert_num_queries):
 
 @pytest.mark.django_db
 def test_device_register(client):
+    # assert that the following test post on an url without trailing slash
+    # as specified by specs
+    assert reverse("agency-0.3:device-list")[-1:] != "/"
+
     provider = factories.Provider(id=uuid.UUID("aaaa0000-61fd-4cce-8113-81af1de90942"))
     device_id = uuid.UUID("bbbb0000-61fd-4cce-8113-81af1de90942")
 
@@ -183,6 +187,10 @@ def test_device_register(client):
 
 @pytest.mark.django_db
 def test_device_event(client):
+    # assert that the following test post on an url without trailing slash
+    # as specified by specs
+    assert reverse("agency-0.3:device-event", args=[1])[-1:] != "/"
+
     provider = factories.Provider(
         id=uuid.UUID("aaaa0000-61fd-4cce-8113-81af1de90942"),
         api_configuration={"agency_api_version": "draft"},
@@ -289,6 +297,10 @@ def test_device_event_inverted_coordinates(client):
 
 @pytest.mark.django_db
 def test_device_telemetry(client, django_assert_num_queries):
+    # assert that the following test post on an url without trailing slash
+    # as specified by specs
+    assert reverse("agency-0.3:device-telemetry")[-1:] != "/"
+
     provider = factories.Provider(id=uuid.UUID("aaaa0000-61fd-4cce-8113-81af1de90942"))
     provider2 = factories.Provider(id=uuid.UUID("aaaa0000-61fd-4cce-8113-81af1de90943"))
     device_id_pattern = "bbbb0000-61fd-4cce-8113-81af1de9094%s"


### PR DESCRIPTION
We should not require the urls to have a trailing slash
see
https://github.com/openmobilityfoundation/mobility-data-specification/tree/0.3.2/agency#vehicle---event