### PR TITLE
provider_poller: split into different implementations

### DIFF
--- a/mds/management/commands/poll_providers.py
+++ b/mds/management/commands/poll_providers.py
@@ -7,11 +7,21 @@ import logging
 
 from django.core import management
 
+from mds import enums
 from mds import models
-from mds.provider_poller import poller
+from mds.provider_poller.poller import v0_2
+from mds.provider_poller.poller import v0_3
+from mds.provider_poller.poller import v0_4
 
 
 logger = logging.getLogger(__name__)
+
+
+version_match = {
+    enums.MDS_VERSIONS.v0_2.name: v0_2,
+    enums.MDS_VERSIONS.v0_3.name: v0_3,
+    enums.MDS_VERSIONS.v0_4.name: v0_4,
+}
 
 
 class Command(management.BaseCommand):
@@ -26,9 +36,22 @@ class Command(management.BaseCommand):
 
     def handle(self, *args, **options):
         for provider in models.Provider.objects.all():
-            logger.debug("Polling provider %s... ", provider.name)
+            # We request a specific version of the Provider API
+            # TODO(hcauwelier) make it mandatory, see SMP-1673
+            api_version_raw = provider.api_configuration.get(
+                "api_version", enums.DEFAULT_PROVIDER_API_VERSION
+            )
+            # We store the enum key, which cannot be a numeric identifier
+            # It doubles as a validity check
+            api_version = enums.MDS_VERSIONS[api_version_raw].value
+            logger.debug(
+                "Polling provider %s using version %s... ", provider.name, api_version
+            )
             try:
-                poller.StatusChangesPoller(provider).poll()
+                # Raise on version mismatch
+                version_match[api_version_raw].StatusChangesPoller(
+                    provider, api_version
+                ).poll()
             except Exception:  # pylint: disable=broad-except
                 # In dev, test... environments, we want explicit errors
                 if options["raise_on_error"]:

--- a/mds/provider_poller/poller/translation.py
+++ b/mds/provider_poller/poller/translation.py
@@ -4,7 +4,7 @@ by translating them to the latest supported version.
 """
 
 
-def translate_v0_2_to_v0_4(data):
+def translate_v0_2(data):
     # The only two noticeable changes from our point of view are:
     # - timestamps converted from floating-point seconds to milliseconds;
     # - "trip_ids" now is a single "trip_id"

--- a/mds/provider_poller/poller/v0_2.py
+++ b/mds/provider_poller/poller/v0_2.py
@@ -2,6 +2,8 @@
 Pulling data for registered providers
 
 This is the opposite of provider pushing their data to the agency API.
+
+TODO(hcauwelier) Should be deleted ASAP
 """
 import datetime
 import enum
@@ -23,8 +25,8 @@ from mds import enums
 from mds import models
 from mds import utils
 from mds.provider_mapping import PROVIDER_REASON_TO_AGENCY_EVENT
-from .oauth2_store import OAuth2Store
-from .translation import translate_v0_2_to_v0_4
+from ..oauth2_store import OAuth2Store
+from .translation import translate_v0_2
 
 
 MDS_CONTENT_TYPE = "application/vnd.mds.provider+json"
@@ -57,8 +59,11 @@ class StatusChangesPoller:
         to_cursor: timestamp or int, upper limit
     """
 
-    def __init__(self, provider, cursor=None, from_cursor=None, to_cursor=None):
+    def __init__(
+        self, provider, api_version, cursor=None, from_cursor=None, to_cursor=None
+    ):
         self.provider = provider
+        self.api_version = api_version
         self.cursor = cursor
         self.from_cursor = from_cursor
         self.to_cursor = to_cursor
@@ -74,21 +79,14 @@ class StatusChangesPoller:
             logger.debug("Provider %s has no URL, skipping.", self.provider.name)
             return
 
-        # We request a specific version of the Provider API
-        # TODO(hcauwelier) make it mandatory, see SMP-1673
-        api_version_raw = self.provider.api_configuration.get(
-            "api_version", enums.DEFAULT_PROVIDER_API_VERSION
+        logger.debug(
+            "Start polling provider %s using version %s",
+            self.provider.name,
+            self.api_version,
         )
-        # We store the enum key, which cannot be a numeric identifier
-        # It doubles as a validity check
-        api_version = enums.MDS_VERSIONS[api_version_raw].value
+        self._poll_status_changes()
 
-        logger.debug("Polling %s using version %s", self.provider.name, api_version)
-
-        getattr(self, "_poll_status_changes_%s" % api_version_raw)(api_version)
-
-    # TODO(hcauwelier) Should be deleted ASAP
-    def _poll_status_changes_v0_2(self, api_version):
+    def _poll_status_changes(self):
         # Start where we left, it's all based on providers sorting by start_time
         # (but we would miss telemetries older than start_time saved after we polled).
         # For those that support it, use the recorded time field or equivalent.
@@ -164,9 +162,9 @@ class StatusChangesPoller:
 
         # Pagination
         while next_url:
-            body = self._get_body(next_url, api_version)
+            body = self._get_body(next_url)
             # Translate older versions of data
-            translated_data = translate_v0_2_to_v0_4(body["data"])
+            translated_data = translate_v0_2(body["data"])
             status_changes = translated_data["status_changes"]
             if not status_changes:
                 break
@@ -217,242 +215,8 @@ class StatusChangesPoller:
                     + f"\tLast skip: {skip_polled}."
                 )
 
-    def _poll_status_changes_v0_3(self, api_version):
-        # Start where we left, it's all based on providers sorting by start_time
-        # (but we would miss telemetries older than start_time saved after we polled).
-        # For those that support it, use the recorded time field or equivalent.
-        polling_cursor = self.cursor or self.provider.api_configuration.get(
-            "polling_cursor", POLLING_CURSORS.start_time.name
-        )
-        logger.info(
-            f"Starting polling {self.provider} using the field: {polling_cursor}.\n"
-            "Current state:\n"
-            + (
-                (
-                    f"\tLast event_time: {str(self.provider.last_event_time_polled)},\n"
-                    + f"\tLast recorded: {str(self.provider.last_recorded_polled)}\n"
-                    + f"\tLast skip: {self.provider.last_skip_polled}."
-                )
-                if not self.cursor
-                else f"\tCursor value: {self.from_cursor}."
-            )
-        )
-
-        params = {}
-
-        # Cursor param (raise if typo)
-        param_name = POLLING_CURSORS[polling_cursor].value
-
-        if polling_cursor == POLLING_CURSORS.total_events.name:
-            # Resume from the last line fetched
-            params[param_name] = self.from_cursor or self.provider.last_skip_polled
-        elif polling_cursor == POLLING_CURSORS.start_recorded.name:
-            # Resume from the last "recorded" value
-            params[param_name] = utils.to_mds_timestamp(
-                self.from_cursor or self.provider.last_recorded_polled
-            )
-        elif polling_cursor == POLLING_CURSORS.start_time.name:
-            # Resume from the last "event_time" value
-            last_event_time_polled = self.provider.last_event_time_polled
-            if not last_event_time_polled:
-                last_event_time_polled = timezone.now() - datetime.timedelta(
-                    getattr(settings, "PROVIDER_POLLER_LIMIT", 90)
-                )
-
-            # But we now apply a "lag" before actually polling,
-            # leaving time for the provider to collect data from its devices
-            polling_lag = self.provider.api_configuration.get("provider_polling_lag")
-            if polling_lag:
-                polling_lag = parse_duration(polling_lag)
-                if (timezone.now() - last_event_time_polled) < polling_lag:
-                    logger.debug("Still under the polling lag, back to sleep.")
-                    return
-
-            params[param_name] = utils.to_mds_timestamp(
-                self.from_cursor or last_event_time_polled
-            )
-
-        # Provider-specific params to optimise polling
-        try:
-            params.update(self.provider.api_configuration["status_changes_params"])
-        except KeyError:
-            pass
-
-        next_url = urllib.parse.urljoin(self.provider.base_api_url, "status_changes")
-        if self.provider.api_configuration.get("trailing_slash"):
-            next_url += "/"
-
-        if params:
-            next_url = "%s?%s" % (next_url, urllib.parse.urlencode(params))
-
-        skip_polled = (
-            self.from_cursor
-            if self.from_cursor and self.cursor == POLLING_CURSORS.total_events.name
-            else None
-        )
-
-        # Pagination
-        while next_url:
-            body = self._get_body(next_url, api_version)
-            # MDS 0.3 is backwards compatible with 0.4
-            status_changes = body["data"]["status_changes"]
-            if not status_changes:
-                break
-
-            next_url = body.get("links", {}).get("next")
-
-            # A transaction for each "page" of data
-            with transaction.atomic():
-                # We get the maximum of the recorded and event_types
-                # from the status changes
-                event_time_polled, recorded_polled = self._process_status_changes(
-                    status_changes
-                )
-
-                if self.cursor:
-                    if self.cursor == POLLING_CURSORS.total_events.name:
-                        skip_polled += len(status_changes)
-                        if skip_polled >= self.to_cursor:
-                            break
-                    elif self.cursor == POLLING_CURSORS.start_recorded.name:
-                        if recorded_polled >= self.to_cursor:
-                            break
-                    elif self.cursor == POLLING_CURSORS.start_time.name:
-                        if event_time_polled >= self.to_cursor:
-                            break
-                else:
-                    # We get the new skip from the number of status changes
-                    skip_polled = (
-                        self.provider.last_skip_polled + len(status_changes)
-                        if self.provider.last_skip_polled
-                        else len(status_changes)
-                    )
-                    self.provider.last_event_time_polled = event_time_polled
-                    self.provider.last_recorded_polled = recorded_polled
-                    self.provider.last_skip_polled = skip_polled
-                    self.provider.save(
-                        update_fields=[
-                            "last_event_time_polled",
-                            "last_recorded_polled",
-                            "last_skip_polled",
-                        ]
-                    )
-
-                logger.info(
-                    f"Polled page using cursor: {polling_cursor}. New state:\n"
-                    + f"\tLast event_time: {str(event_time_polled)},\n"
-                    + f"\tLast recorded: {str(recorded_polled)}\n"
-                    + f"\tLast skip: {skip_polled}."
-                )
-
-    def _poll_status_changes_v0_4(self, api_version):
-        # Start where we left, it's all based on providers sorting by start_time
-        # (but we would miss telemetries older than start_time saved after we polled).
-        # For those that support it, use the recorded time field or equivalent.
-        polling_cursor = self.cursor or self.provider.api_configuration.get(
-            "polling_cursor", POLLING_CURSORS.start_time.name
-        )
-        if polling_cursor != POLLING_CURSORS.start_time.name:
-            raise ValueError('Only "start_time" cursor is supported in MDS 0.4+')
-        logger.info(
-            f"Starting polling {self.provider} using the field: {polling_cursor}.\n"
-            "Current state:\n"
-            + (
-                (f"\tLast event_time: {str(self.provider.last_event_time_polled)}.")
-                if not self.cursor
-                else f"\tCursor value: {self.from_cursor}."
-            )
-        )
-
-        params = {}
-
-        # Resume from the last "event_time" value
-        last_event_time_polled = self.provider.last_event_time_polled
-        if not last_event_time_polled:
-            last_event_time_polled = timezone.now() - datetime.timedelta(
-                getattr(settings, "PROVIDER_POLLER_LIMIT", 90)
-            )
-
-        # But we now apply a "lag" before actually polling,
-        # leaving time for the provider to collect data from its devices
-        polling_lag = self.provider.api_configuration.get("provider_polling_lag")
-        if polling_lag:
-            polling_lag = parse_duration(polling_lag)
-            if (timezone.now() - last_event_time_polled) < polling_lag:
-                logger.info("Still under the polling lag, back to sleep.")
-                return
-
-        # The MDS 0.4 Provider API got two endpoints:
-        # - /events for the real-time or so data (formerly /status_changes)
-        #   but limited to two weeks of history
-        # - /status_changes for all the data except the current hour
-        # If we're catching up far in time, begin by polling /status_changes
-        realtime_threshold = parse_duration(  # Default is 9 days
-            self.provider.api_configuration.get("realtime_threshold", "P9D")
-        )
-        next_event_time = last_event_time_polled + datetime.timedelta(hours=1)
-        if (timezone.now() - next_event_time) > realtime_threshold:
-            # We have to query the archived status changes with another format
-            logger.info("last_event_time_polled is too old, asking archives")
-            # We're done with the events of the last hour, ask the next hour
-            params["event_time"] = next_event_time.isoformat()[: len("YYYY-MM-DDTHH")]
-        else:
-            # Query the real-time endpoint as usual
-            params["start_time"] = utils.to_mds_timestamp(
-                self.from_cursor or last_event_time_polled
-            )
-
-        # Provider-specific params to optimise polling
-        try:
-            params.update(self.provider.api_configuration["status_changes_params"])
-        except KeyError:
-            pass
-
-        endpoint = "events"  # The new name for the real-time events endpoint
-        if "event_time" in params:
-            # We asked the archived status changes instead
-            endpoint = "status_changes"
-        next_url = urllib.parse.urljoin(self.provider.base_api_url, endpoint)
-        if self.provider.api_configuration.get("trailing_slash"):
-            next_url += "/"
-
-        if params:
-            next_url = "%s?%s" % (next_url, urllib.parse.urlencode(params))
-
-        # Pagination
-        while next_url:
-            body = self._get_body(next_url, api_version)
-            # No translation needed as long as 0.4 is the latest version
-            status_changes = body["data"]["status_changes"]
-            next_url = body.get("links", {}).get("next")
-
-            # A transaction for each "page" of data
-            with transaction.atomic():
-                if status_changes:
-                    # We get the maximum values from the status changes
-                    event_time_polled, _ = self._process_status_changes(status_changes)
-                elif endpoint == "status_changes":
-                    # This hour frame of archives didn't contain results
-                    event_time_polled = next_event_time
-                else:
-                    # Try again from this point later
-                    break
-
-                if self.cursor:
-                    if self.cursor == POLLING_CURSORS.start_time.name:
-                        if event_time_polled >= self.to_cursor:
-                            break
-                else:
-                    self.provider.last_event_time_polled = event_time_polled
-                    self.provider.save(update_fields=["last_event_time_polled"])
-
-                logger.info(
-                    f"Polled page using cursor: {polling_cursor}. New state:\n"
-                    + f"\tLast event_time: {str(event_time_polled)}."
-                )
-
     @retry(stop_max_attempt_number=2)
-    def _get_body(self, url, api_version):
+    def _get_body(self, url):
         authentication_type = self.provider.api_authentication.get("type")
         if authentication_type in (None, "", "none"):
             client = requests
@@ -463,18 +227,12 @@ class StatusChangesPoller:
 
         headers = {}
 
-        # TODO(hcauwelier) just fork the code for MDS 0.4
-        if api_version == "0.4":
-            # We only accept the version we expect from that provider
-            # And it should reject it when it bumps to the new version
-            headers["Accept"] = "%s;version=%s" % (MDS_CONTENT_TYPE, api_version)
-        else:
-            # TODO(hcauwelier) some server implementations are flawed
-            # leave the standard content type for now
-            headers["Accept"] = "application/json,%s;version=%s" % (
-                MDS_CONTENT_TYPE,
-                api_version,
-            )
+        # MDS 0.2 didn't have versioning headers,
+        # Use the standard content type first
+        headers["Accept"] = "application/json,%s;version=%s" % (
+            MDS_CONTENT_TYPE,
+            self.api_version,
+        )
 
         logger.debug("Polling provider on URL %s with headers %s", url, headers)
         response = client.get(url, timeout=30, headers=headers)
@@ -497,11 +255,11 @@ class StatusChangesPoller:
             assert content_type == MDS_CONTENT_TYPE
             params = dict(param.split("=") for param in params)
             received = params.get("version", "unspecified")
-        if received != api_version:
+        if received != self.api_version:
             logger.warning(
                 "Provider %s didn't respond in version %s but %s",
                 self.provider.name,
-                api_version,
+                self.api_version,
                 received,
             )
 

--- a/mds/provider_poller/poller/v0_3.py
+++ b/mds/provider_poller/poller/v0_3.py
@@ -1,0 +1,217 @@
+"""
+Pulling data for registered providers
+
+This is the opposite of provider pushing their data to the agency API.
+"""
+import datetime
+import enum
+import logging
+import urllib.parse
+
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+from django.utils.dateparse import parse_duration
+
+import requests
+from retrying import retry
+
+from mds import utils
+
+from . import v0_2
+
+
+MDS_CONTENT_TYPE = "application/vnd.mds.provider+json"
+
+
+logger = logging.getLogger(__name__)
+
+
+# polling_cursor configuration field translated to query parameter
+class POLLING_CURSORS(enum.Enum):
+    start_time = "start_time"  # from the MDS specification
+    start_recorded = "start_recorded"  # vendor only, 0.3 only
+    total_events = "skip"  # vendor only, 0.3 only
+
+
+class StatusChangesPoller(v0_2.StatusChangesPoller):
+    """Override only what changed between 0.2 and 0.3."""
+
+    def _poll_status_changes(self):
+        # Start where we left, it's all based on providers sorting by start_time
+        # (but we would miss telemetries older than start_time saved after we polled).
+        # For those that support it, use the recorded time field or equivalent.
+        polling_cursor = self.cursor or self.provider.api_configuration.get(
+            "polling_cursor", POLLING_CURSORS.start_time.name
+        )
+        logger.info(
+            f"Starting polling {self.provider} using the field: {polling_cursor}.\n"
+            "Current state:\n"
+            + (
+                (
+                    f"\tLast event_time: {str(self.provider.last_event_time_polled)},\n"
+                    + f"\tLast recorded: {str(self.provider.last_recorded_polled)}\n"
+                    + f"\tLast skip: {self.provider.last_skip_polled}."
+                )
+                if not self.cursor
+                else f"\tCursor value: {self.from_cursor}."
+            )
+        )
+
+        params = {}
+
+        # Cursor param (raise if typo)
+        param_name = POLLING_CURSORS[polling_cursor].value
+
+        if polling_cursor == POLLING_CURSORS.total_events.name:
+            # Resume from the last line fetched
+            params[param_name] = self.from_cursor or self.provider.last_skip_polled
+        elif polling_cursor == POLLING_CURSORS.start_recorded.name:
+            # Resume from the last "recorded" value
+            params[param_name] = utils.to_mds_timestamp(
+                self.from_cursor or self.provider.last_recorded_polled
+            )
+        elif polling_cursor == POLLING_CURSORS.start_time.name:
+            # Resume from the last "event_time" value
+            last_event_time_polled = self.provider.last_event_time_polled
+            if not last_event_time_polled:
+                last_event_time_polled = timezone.now() - datetime.timedelta(
+                    getattr(settings, "PROVIDER_POLLER_LIMIT", 90)
+                )
+
+            # But we now apply a "lag" before actually polling,
+            # leaving time for the provider to collect data from its devices
+            polling_lag = self.provider.api_configuration.get("provider_polling_lag")
+            if polling_lag:
+                polling_lag = parse_duration(polling_lag)
+                if (timezone.now() - last_event_time_polled) < polling_lag:
+                    logger.debug("Still under the polling lag, back to sleep.")
+                    return
+
+            params[param_name] = utils.to_mds_timestamp(
+                self.from_cursor or last_event_time_polled
+            )
+
+        # Provider-specific params to optimise polling
+        try:
+            params.update(self.provider.api_configuration["status_changes_params"])
+        except KeyError:
+            pass
+
+        next_url = urllib.parse.urljoin(self.provider.base_api_url, "status_changes")
+        if self.provider.api_configuration.get("trailing_slash"):
+            next_url += "/"
+
+        if params:
+            next_url = "%s?%s" % (next_url, urllib.parse.urlencode(params))
+
+        skip_polled = (
+            self.from_cursor
+            if self.from_cursor and self.cursor == POLLING_CURSORS.total_events.name
+            else None
+        )
+
+        # Pagination
+        while next_url:
+            body = self._get_body(next_url)
+            # MDS 0.3 is backwards compatible with 0.4
+            status_changes = body["data"]["status_changes"]
+            if not status_changes:
+                break
+
+            next_url = body.get("links", {}).get("next")
+
+            # A transaction for each "page" of data
+            with transaction.atomic():
+                # We get the maximum of the recorded and event_types
+                # from the status changes
+                event_time_polled, recorded_polled = self._process_status_changes(
+                    status_changes
+                )
+
+                if self.cursor:
+                    if self.cursor == POLLING_CURSORS.total_events.name:
+                        skip_polled += len(status_changes)
+                        if skip_polled >= self.to_cursor:
+                            break
+                    elif self.cursor == POLLING_CURSORS.start_recorded.name:
+                        if recorded_polled >= self.to_cursor:
+                            break
+                    elif self.cursor == POLLING_CURSORS.start_time.name:
+                        if event_time_polled >= self.to_cursor:
+                            break
+                else:
+                    # We get the new skip from the number of status changes
+                    skip_polled = (
+                        self.provider.last_skip_polled + len(status_changes)
+                        if self.provider.last_skip_polled
+                        else len(status_changes)
+                    )
+                    self.provider.last_event_time_polled = event_time_polled
+                    self.provider.last_recorded_polled = recorded_polled
+                    self.provider.last_skip_polled = skip_polled
+                    self.provider.save(
+                        update_fields=[
+                            "last_event_time_polled",
+                            "last_recorded_polled",
+                            "last_skip_polled",
+                        ]
+                    )
+
+                logger.info(
+                    f"Polled page using cursor: {polling_cursor}. New state:\n"
+                    + f"\tLast event_time: {str(event_time_polled)},\n"
+                    + f"\tLast recorded: {str(recorded_polled)}\n"
+                    + f"\tLast skip: {skip_polled}."
+                )
+
+    @retry(stop_max_attempt_number=2)
+    def _get_body(self, url):
+        authentication_type = self.provider.api_authentication.get("type")
+        if authentication_type in (None, "", "none"):
+            client = requests
+        elif authentication_type == "oauth2":
+            client = self.oauth2_store.get_client()
+        else:
+            raise NotImplementedError
+
+        headers = {}
+
+        # Some server implementations are flawed
+        # leave the standard content type even in 0.3
+        headers["Accept"] = "application/json,%s;version=%s" % (
+            MDS_CONTENT_TYPE,
+            self.api_version,
+        )
+
+        logger.debug("Polling provider on URL %s with headers %s", url, headers)
+        response = client.get(url, timeout=30, headers=headers)
+        # Token may be expired sooner than expected, retry in one minute
+        if response.status_code in (401, 403):
+            self.oauth2_store.flush_token()
+        response.raise_for_status()
+
+        # Servers should send what version of the API was served
+        # but we rather trust the versioning in the body
+        content_type = response.headers.get(
+            "Content-Type", "application/json; charset=UTF-8"
+        )
+        if content_type.startswith("application/json"):
+            received = "unspecified"
+        else:
+            # Let it raise if malformed
+            params = content_type.split(";")
+            content_type = params.pop(0)
+            assert content_type == MDS_CONTENT_TYPE
+            params = dict(param.split("=") for param in params)
+            received = params.get("version", "unspecified")
+        if received != self.api_version:
+            logger.warning(
+                "Provider %s didn't respond in version %s but %s",
+                self.provider.name,
+                self.api_version,
+                received,
+            )
+
+        body = response.json()
+        return body

--- a/mds/provider_poller/poller/v0_4.py
+++ b/mds/provider_poller/poller/v0_4.py
@@ -1,0 +1,191 @@
+"""
+Pulling data for registered providers
+
+This is the opposite of provider pushing their data to the agency API.
+"""
+import datetime
+import enum
+import logging
+import urllib.parse
+
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+from django.utils.dateparse import parse_duration
+
+import requests
+from retrying import retry
+
+from mds import utils
+
+from . import v0_3
+
+
+MDS_CONTENT_TYPE = "application/vnd.mds.provider+json"
+
+
+logger = logging.getLogger(__name__)
+
+
+# polling_cursor configuration field translated to query parameter
+class POLLING_CURSORS(enum.Enum):
+    start_time = "start_time"  # from the MDS specification
+
+
+class StatusChangesPoller(v0_3.StatusChangesPoller):
+    """Override only what changed between 0.3 and 0.4."""
+
+    def _poll_status_changes(self):
+        # Start where we left, it's all based on providers sorting by start_time
+        # (but we would miss telemetries older than start_time saved after we polled).
+        # For those that support it, use the recorded time field or equivalent.
+        polling_cursor = self.cursor or self.provider.api_configuration.get(
+            "polling_cursor", POLLING_CURSORS.start_time.name
+        )
+        # We dropped other cursor types
+        if polling_cursor != POLLING_CURSORS.start_time.name:
+            raise ValueError('Only "start_time" cursor is supported in MDS 0.4+')
+        logger.info(
+            f"Starting polling {self.provider} using the field: {polling_cursor}.\n"
+            "Current state:\n"
+            + (
+                (f"\tLast event_time: {str(self.provider.last_event_time_polled)}.")
+                if not self.cursor
+                else f"\tCursor value: {self.from_cursor}."
+            )
+        )
+
+        params = {}
+
+        # Resume from the last "event_time" value
+        last_event_time_polled = self.provider.last_event_time_polled
+        if not last_event_time_polled:
+            last_event_time_polled = timezone.now() - datetime.timedelta(
+                getattr(settings, "PROVIDER_POLLER_LIMIT", 90)
+            )
+
+        # But we now apply a "lag" before actually polling,
+        # leaving time for the provider to collect data from its devices
+        polling_lag = self.provider.api_configuration.get("provider_polling_lag")
+        if polling_lag:
+            polling_lag = parse_duration(polling_lag)
+            if (timezone.now() - last_event_time_polled) < polling_lag:
+                logger.info("Still under the polling lag, back to sleep.")
+                return
+
+        # The MDS 0.4 Provider API got two endpoints:
+        # - /events for the real-time or so data (formerly /status_changes)
+        #   but limited to two weeks of history
+        # - /status_changes for all the data except the current hour
+        # If we're catching up far in time, begin by polling /status_changes
+        realtime_threshold = parse_duration(  # Default is 9 days
+            self.provider.api_configuration.get("realtime_threshold", "P9D")
+        )
+        next_event_time = last_event_time_polled + datetime.timedelta(hours=1)
+        if (timezone.now() - next_event_time) > realtime_threshold:
+            # We have to query the archived status changes with another format
+            logger.info("last_event_time_polled is too old, asking archives")
+            # We're done with the events of the last hour, ask the next hour
+            params["event_time"] = next_event_time.isoformat()[: len("YYYY-MM-DDTHH")]
+        else:
+            # Query the real-time endpoint as usual
+            params["start_time"] = utils.to_mds_timestamp(
+                self.from_cursor or last_event_time_polled
+            )
+
+        # Provider-specific params to optimise polling
+        try:
+            params.update(self.provider.api_configuration["status_changes_params"])
+        except KeyError:
+            pass
+
+        endpoint = "events"  # The new name for the real-time events endpoint
+        if "event_time" in params:
+            # We asked the archived status changes instead
+            endpoint = "status_changes"
+        next_url = urllib.parse.urljoin(self.provider.base_api_url, endpoint)
+        if self.provider.api_configuration.get("trailing_slash"):
+            next_url += "/"
+
+        if params:
+            next_url = "%s?%s" % (next_url, urllib.parse.urlencode(params))
+
+        # Pagination
+        while next_url:
+            body = self._get_body(next_url)
+            # No translation needed as long as 0.4 is the latest version
+            status_changes = body["data"]["status_changes"]
+            next_url = body.get("links", {}).get("next")
+
+            # A transaction for each "page" of data
+            with transaction.atomic():
+                if status_changes:
+                    # We get the maximum values from the status changes
+                    event_time_polled, _ = self._process_status_changes(status_changes)
+                elif endpoint == "status_changes":
+                    # This hour frame of archives didn't contain results
+                    event_time_polled = next_event_time
+                else:
+                    # Try again from this point later
+                    break
+
+                if self.cursor:
+                    if self.cursor == POLLING_CURSORS.start_time.name:
+                        if event_time_polled >= self.to_cursor:
+                            break
+                else:
+                    self.provider.last_event_time_polled = event_time_polled
+                    self.provider.save(update_fields=["last_event_time_polled"])
+
+                logger.info(
+                    f"Polled page using cursor: {polling_cursor}. New state:\n"
+                    + f"\tLast event_time: {str(event_time_polled)}."
+                )
+
+    @retry(stop_max_attempt_number=2)
+    def _get_body(self, url):
+        authentication_type = self.provider.api_authentication.get("type")
+        if authentication_type in (None, "", "none"):
+            client = requests
+        elif authentication_type == "oauth2":
+            client = self.oauth2_store.get_client()
+        else:
+            raise NotImplementedError
+
+        headers = {}
+
+        # We only accept the version we expect from that provider
+        # And it should reject it when it bumps to the new version
+        headers["Accept"] = "%s;version=%s" % (MDS_CONTENT_TYPE, self.api_version)
+
+        logger.debug("Polling provider on URL %s with headers %s", url, headers)
+        response = client.get(url, timeout=30, headers=headers)
+        # Token may be expired sooner than expected, retry in one minute
+        if response.status_code in (401, 403):
+            self.oauth2_store.flush_token()
+        response.raise_for_status()
+
+        # Servers should send what version of the API was served
+        # but we rather trust the versioning in the body
+        content_type = response.headers.get(
+            "Content-Type", "application/json; charset=UTF-8"
+        )
+        if content_type.startswith("application/json"):
+            received = "unspecified"
+        else:
+            # Let it raise if malformed
+            params = content_type.split(";")
+            content_type = params.pop(0)
+            assert content_type == MDS_CONTENT_TYPE
+            params = dict(param.split("=") for param in params)
+            received = params.get("version", "unspecified")
+        if received != self.api_version:
+            logger.warning(
+                "Provider %s didn't respond in version %s but %s",
+                self.provider.name,
+                self.api_version,
+                received,
+            )
+
+        body = response.json()
+        return body

--- a/tests/management/commands/test_poll_providers_v0_3.py
+++ b/tests/management/commands/test_poll_providers_v0_3.py
@@ -1,0 +1,200 @@
+import datetime
+import io
+import urllib.parse
+
+import pytest
+
+from django.core.management import call_command
+from django.utils import timezone
+
+from mds import enums
+from mds import factories
+from mds import models
+
+from . import utils
+
+
+@pytest.mark.django_db
+def test_poll_provider_batch(client, settings, requests_mock):
+    """A single provider with two pages of status changes."""
+    settings.POLLER_CREATE_REGISTER_EVENTS = True
+    provider = factories.Provider(base_api_url="http://provider")
+    # The first device received already exists
+    device1 = factories.Device(provider=provider)
+    expected_event1 = factories.EventRecord.build(
+        event_type=enums.EVENT_TYPE.service_start.name,
+        properties__trip_id="e7a9d3aa-68ea-4666-8adf-7bad40e49805",
+    )
+    # The second device received is unknown
+    expected_device2 = factories.Device.build()
+    expected_event2 = factories.EventRecord.build(
+        event_type=enums.EVENT_TYPE.trip_end.name
+    )
+    stdout, stderr = io.StringIO(), io.StringIO()
+
+    url = urllib.parse.urljoin(provider.base_api_url, "/status_changes")
+    next_page = "%s?page=2" % url
+    requests_mock.get(
+        url,
+        json=utils.make_response(
+            provider,
+            device1,
+            expected_event1,
+            event_type_reason="service_start",
+            associated_trip="e7a9d3aa-68ea-4666-8adf-7bad40e49805",
+            next_page=next_page,
+        ),
+    )
+    requests_mock.get(
+        next_page,
+        json=utils.make_response(
+            provider,
+            expected_device2,
+            expected_event2,
+            event_type_reason="maintenance_pick_up",
+        ),
+    )
+    call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
+
+    utils.assert_command_success(stdout, stderr)
+
+    event1 = device1.event_records.get()
+    utils.assert_event_equal(event1, expected_event1)
+
+    # The second device was created on the fly
+    device2 = models.Device.objects.get(pk=expected_device2.pk)
+    assert device2.saved_at is not None
+    # With a fake register event and the actual event
+    event2_register, event2_regular = device2.event_records.order_by("timestamp")
+
+    assert event2_register.event_type == enums.EVENT_TYPE.register.name
+    assert event2_register.properties == {"created_on_register": True}
+    utils.assert_event_equal(event2_regular, expected_event2)
+    utils.assert_device_equal(device2, expected_device2)
+
+
+@pytest.mark.django_db
+def test_several_providers(client, django_assert_num_queries, settings, requests_mock):
+    """Two providers this time."""
+    settings.POLLER_CREATE_REGISTER_EVENTS = True
+    provider1 = factories.Provider(base_api_url="http://provider1")
+    device1 = factories.Device.build(provider=provider1)
+    expected_event1 = factories.EventRecord.build(
+        event_type=enums.EVENT_TYPE.provider_drop_off.name
+    )
+    provider2 = factories.Provider(base_api_url="http://provider2")
+    device2 = factories.Device.build(provider=provider2)
+    expected_event2 = factories.EventRecord.build(
+        event_type=enums.EVENT_TYPE.trip_start.name
+    )
+    stdout, stderr = io.StringIO(), io.StringIO()
+
+    n = 1  # List of providers
+    n += 2  # List of provider IDs (for each provider)
+    n += 2  # List of device IDs (for each provider)
+    n += (
+        2  # Savepoint/release for each provider
+        + 1  # Insert missing devices
+        + 1  # Insert fake register event
+        + 1  # Insert missing event records
+        + 1  # Update last start time polled
+    ) * 2  # For each provider
+    with django_assert_num_queries(n):
+        requests_mock.get(
+            urllib.parse.urljoin(provider1.base_api_url, "/status_changes"),
+            json=utils.make_response(
+                provider1,
+                device1,
+                expected_event1,
+                event_type_reason="rebalance_drop_off",
+            ),
+        )
+        requests_mock.get(
+            urllib.parse.urljoin(provider2.base_api_url, "/status_changes"),
+            json=utils.make_response(
+                provider2, device2, expected_event2, event_type_reason="maintenance"
+            ),
+        )
+        call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
+
+    utils.assert_command_success(stdout, stderr)
+
+    event1_register, event1_regular = device1.event_records.order_by("timestamp")
+    assert event1_register.event_type == enums.EVENT_TYPE.register.name
+    assert event1_register.properties == {"created_on_register": True}
+    utils.assert_event_equal(event1_regular, expected_event1)
+
+    event2_register, event2_regular = device2.event_records.order_by("timestamp")
+    assert event2_register.event_type == enums.EVENT_TYPE.register.name
+    assert event2_register.properties == {"created_on_register": True}
+    utils.assert_event_equal(event2_regular, expected_event2)
+
+
+@pytest.mark.django_db
+def test_follow_up(client, settings, requests_mock):
+    """Catching up new telemetries from the last one we got."""
+    settings.POLLER_CREATE_REGISTER_EVENTS = True
+    event = factories.EventRecord(device__provider__base_api_url="http://provider")
+    device = event.device
+    provider = device.provider
+    provider.last_event_time_polled = event.timestamp
+    provider.save()
+    expected_event = factories.EventRecord.build(
+        event_type=enums.EVENT_TYPE.service_end.name, timestamp=timezone.now()
+    )
+    stdout, stderr = io.StringIO(), io.StringIO()
+
+    # Mocking must fail if the command does not make the expected query
+    requests_mock.get(
+        urllib.parse.urljoin(provider.base_api_url, "/status_changes"), status_code=400,
+    )
+    requests_mock.get(
+        urllib.parse.urljoin(
+            provider.base_api_url,
+            "/status_changes?%s"
+            % urllib.parse.urlencode(
+                {"start_time": round(event.timestamp.timestamp() * 1000)}
+            ),
+        ),
+        json=utils.make_response(
+            provider, device, expected_event, event_type_reason="service_end"
+        ),
+    )
+    call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
+
+    utils.assert_command_success(stdout, stderr)
+
+    assert device.event_records.count() == 2
+    event = device.event_records.latest("timestamp")
+    utils.assert_event_equal(event, expected_event)
+
+
+@pytest.mark.django_db
+def test_poll_provider_lag(client, requests_mock):
+    # Note: testing with the default "POLLER_CREATE_REGISTER_EVENTS = False"
+    # Below the lag threshold
+    last_event_time_polled = timezone.now() - datetime.timedelta(minutes=30)
+    provider = factories.Provider(
+        base_api_url="http://provider",
+        api_configuration__provider_polling_lag="PT1H",  # One hour
+        last_event_time_polled=last_event_time_polled,
+    )
+    stdout, stderr = io.StringIO(), io.StringIO()
+
+    # No endpoint should be called
+    requests_mock.get(
+        urllib.parse.urljoin(provider.base_api_url, "/events"), status_code=400,
+    )
+    requests_mock.get(
+        urllib.parse.urljoin(provider.base_api_url, "/status_changes"), status_code=400,
+    )
+    call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
+
+    utils.assert_command_success(stdout, stderr)
+    # The last poller cursor is NOT updated
+    provider = models.Provider.objects.get(pk=provider.pk)
+    assert provider.last_event_time_polled == last_event_time_polled
+    # No device created
+    assert models.Device.objects.count() == 0
+    # No event created
+    assert models.EventRecord.objects.count() == 0

--- a/tests/management/commands/test_poll_providers_v0_4.py
+++ b/tests/management/commands/test_poll_providers_v0_4.py
@@ -10,17 +10,19 @@ from django.utils import timezone
 from mds import enums
 from mds import factories
 from mds import models
-from mds.provider_mapping import (
-    PROVIDER_REASON_TO_AGENCY_EVENT,
-    PROVIDER_EVENT_TYPE_REASON_TO_EVENT_TYPE,
-)
+
+from . import utils
+
+# Note: testing with the default "POLLER_CREATE_REGISTER_EVENTS = False"
 
 
 @pytest.mark.django_db
-def test_poll_provider_batch(client, settings, requests_mock):
+def test_poll_provider_batch(client, requests_mock):
     """A single provider with two pages of status changes."""
-    settings.POLLER_CREATE_REGISTER_EVENTS = True
-    provider = factories.Provider(base_api_url="http://provider")
+    provider = factories.Provider(
+        base_api_url="http://provider",
+        api_configuration__api_version=enums.MDS_VERSIONS.v0_4.name,
+    )
     # The first device received already exists
     device1 = factories.Device(provider=provider)
     expected_event1 = factories.EventRecord.build(
@@ -34,57 +36,62 @@ def test_poll_provider_batch(client, settings, requests_mock):
     )
     stdout, stderr = io.StringIO(), io.StringIO()
 
+    # As we're starting before the threshold, we'll poll the archives endpoint
     url = urllib.parse.urljoin(provider.base_api_url, "/status_changes")
     next_page = "%s?page=2" % url
     requests_mock.get(
         url,
-        json=make_response(
+        json=utils.make_response(
             provider,
             device1,
             expected_event1,
             event_type_reason="service_start",
             associated_trip="e7a9d3aa-68ea-4666-8adf-7bad40e49805",
             next_page=next_page,
+            version="0.4.0",
         ),
     )
     requests_mock.get(
         next_page,
-        json=make_response(
+        json=utils.make_response(
             provider,
             expected_device2,
             expected_event2,
             event_type_reason="maintenance_pick_up",
+            version="0.4.0",
         ),
     )
     call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
 
-    assert_command_success(stdout, stderr)
+    utils.assert_command_success(stdout, stderr)
 
     event1 = device1.event_records.get()
-    assert_event_equal(event1, expected_event1)
+    utils.assert_event_equal(event1, expected_event1)
 
     # The second device was created on the fly
     device2 = models.Device.objects.get(pk=expected_device2.pk)
     assert device2.saved_at is not None
-    # With a fake register event and the actual event
-    event2_register, event2_regular = device2.event_records.order_by("timestamp")
+    event2 = device2.event_records.get()
 
-    assert event2_register.event_type == enums.EVENT_TYPE.register.name
-    assert event2_register.properties == {"created_on_register": True}
-    assert_event_equal(event2_regular, expected_event2)
-    assert_device_equal(device2, expected_device2)
+    utils.assert_event_equal(event2, expected_event2)
+    utils.assert_device_equal(device2, expected_device2)
 
 
 @pytest.mark.django_db
-def test_several_providers(client, django_assert_num_queries, settings, requests_mock):
+def test_several_providers(client, django_assert_num_queries, requests_mock):
     """Two providers this time."""
-    settings.POLLER_CREATE_REGISTER_EVENTS = True
-    provider1 = factories.Provider(base_api_url="http://provider1")
+    provider1 = factories.Provider(
+        base_api_url="http://provider1",
+        api_configuration__api_version=enums.MDS_VERSIONS.v0_4.name,
+    )
     device1 = factories.Device.build(provider=provider1)
     expected_event1 = factories.EventRecord.build(
         event_type=enums.EVENT_TYPE.provider_drop_off.name
     )
-    provider2 = factories.Provider(base_api_url="http://provider2")
+    provider2 = factories.Provider(
+        base_api_url="http://provider2",
+        api_configuration__api_version=enums.MDS_VERSIONS.v0_4.name,
+    )
     device2 = factories.Device.build(provider=provider2)
     expected_event2 = factories.EventRecord.build(
         event_type=enums.EVENT_TYPE.trip_start.name
@@ -97,46 +104,48 @@ def test_several_providers(client, django_assert_num_queries, settings, requests
     n += (
         2  # Savepoint/release for each provider
         + 1  # Insert missing devices
-        + 1  # Insert fake register event
         + 1  # Insert missing event records
         + 1  # Update last start time polled
     ) * 2  # For each provider
     with django_assert_num_queries(n):
         requests_mock.get(
             urllib.parse.urljoin(provider1.base_api_url, "/status_changes"),
-            json=make_response(
+            json=utils.make_response(
                 provider1,
                 device1,
                 expected_event1,
                 event_type_reason="rebalance_drop_off",
+                version="0.4.0",
             ),
         )
         requests_mock.get(
             urllib.parse.urljoin(provider2.base_api_url, "/status_changes"),
-            json=make_response(
-                provider2, device2, expected_event2, event_type_reason="maintenance"
+            json=utils.make_response(
+                provider2,
+                device2,
+                expected_event2,
+                event_type_reason="maintenance",
+                version="0.4.0",
             ),
         )
         call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
 
-    assert_command_success(stdout, stderr)
+    utils.assert_command_success(stdout, stderr)
 
-    event1_register, event1_regular = device1.event_records.order_by("timestamp")
-    assert event1_register.event_type == enums.EVENT_TYPE.register.name
-    assert event1_register.properties == {"created_on_register": True}
-    assert_event_equal(event1_regular, expected_event1)
+    event1 = device1.event_records.get()
+    utils.assert_event_equal(event1, expected_event1)
 
-    event2_register, event2_regular = device2.event_records.order_by("timestamp")
-    assert event2_register.event_type == enums.EVENT_TYPE.register.name
-    assert event2_register.properties == {"created_on_register": True}
-    assert_event_equal(event2_regular, expected_event2)
+    event2 = device2.event_records.get()
+    utils.assert_event_equal(event2, expected_event2)
 
 
 @pytest.mark.django_db
-def test_follow_up(client, settings, requests_mock):
+def test_follow_up(client, requests_mock):
     """Catching up new telemetries from the last one we got."""
-    settings.POLLER_CREATE_REGISTER_EVENTS = True
-    event = factories.EventRecord(device__provider__base_api_url="http://provider")
+    event = factories.EventRecord(
+        device__provider__base_api_url="http://provider",
+        device__provider__api_configuration__api_version=enums.MDS_VERSIONS.v0_4.name,
+    )
     device = event.device
     provider = device.provider
     provider.last_event_time_polled = event.timestamp
@@ -148,32 +157,36 @@ def test_follow_up(client, settings, requests_mock):
 
     # Mocking must fail if the command does not make the expected query
     requests_mock.get(
-        urllib.parse.urljoin(provider.base_api_url, "/status_changes"), status_code=400,
+        urllib.parse.urljoin(provider.base_api_url, "/events"), status_code=400,
     )
     requests_mock.get(
         urllib.parse.urljoin(
             provider.base_api_url,
-            "/status_changes?%s"
+            "/events?%s"
             % urllib.parse.urlencode(
                 {"start_time": round(event.timestamp.timestamp() * 1000)}
             ),
         ),
-        json=make_response(
-            provider, device, expected_event, event_type_reason="service_end"
+        json=utils.make_response(
+            provider,
+            device,
+            expected_event,
+            event_type_reason="service_end",
+            version="0.4.0",
         ),
     )
     call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
 
-    assert_command_success(stdout, stderr)
+    utils.assert_command_success(stdout, stderr)
 
+    # The existing one and the new one
     assert device.event_records.count() == 2
     event = device.event_records.latest("timestamp")
-    assert_event_equal(event, expected_event)
+    utils.assert_event_equal(event, expected_event)
 
 
 @pytest.mark.django_db
-def test_poll_provider_v0_4_archives(client, requests_mock):
-    # Note: testing with the default "POLLER_CREATE_REGISTER_EVENTS = False"
+def test_poll_provider_archives(client, requests_mock):
     provider = factories.Provider(
         base_api_url="http://provider",
         api_configuration__api_version=enums.MDS_VERSIONS.v0_4.name,
@@ -189,7 +202,7 @@ def test_poll_provider_v0_4_archives(client, requests_mock):
     status_changes = urllib.parse.urljoin(provider.base_api_url, "/status_changes")
     requests_mock.get(
         status_changes,
-        json=make_response(
+        json=utils.make_response(
             provider,
             expected_device,
             expected_event,
@@ -203,7 +216,7 @@ def test_poll_provider_v0_4_archives(client, requests_mock):
     )
     call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
 
-    assert_command_success(stdout, stderr)
+    utils.assert_command_success(stdout, stderr)
     # The last poller cursor is updated
     provider = models.Provider.objects.get(pk=provider.pk)
     assert provider.last_event_time_polled is not None
@@ -213,13 +226,12 @@ def test_poll_provider_v0_4_archives(client, requests_mock):
     # The actual event
     event = device.event_records.get()
     assert event.event_type == enums.EVENT_TYPE.service_start.name
-    assert_event_equal(event, expected_event)
-    assert_device_equal(device, expected_device)
+    utils.assert_event_equal(event, expected_event)
+    utils.assert_device_equal(device, expected_device)
 
 
 @pytest.mark.django_db
-def test_poll_provider_v0_4_archives_resume(client, requests_mock):
-    # Note: testing with the default "POLLER_CREATE_REGISTER_EVENTS = False"
+def test_poll_provider_archives_resume(client, requests_mock):
     last_event_time_polled = datetime.datetime(
         2019, 10, 16, 14, 40, 35, tzinfo=timezone.utc
     )
@@ -239,7 +251,7 @@ def test_poll_provider_v0_4_archives_resume(client, requests_mock):
     status_changes = urllib.parse.urljoin(provider.base_api_url, "/status_changes")
     requests_mock.get(
         status_changes,
-        json=make_response(
+        json=utils.make_response(
             provider,
             expected_device,
             expected_event,
@@ -253,7 +265,7 @@ def test_poll_provider_v0_4_archives_resume(client, requests_mock):
     )
     call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
 
-    assert_command_success(stdout, stderr)
+    utils.assert_command_success(stdout, stderr)
     # The last poller cursor is updated
     provider = models.Provider.objects.get(pk=provider.pk)
     assert provider.last_event_time_polled > last_event_time_polled
@@ -263,13 +275,12 @@ def test_poll_provider_v0_4_archives_resume(client, requests_mock):
     # The actual event
     event = device.event_records.get()
     assert event.event_type == enums.EVENT_TYPE.service_start.name
-    assert_event_equal(event, expected_event)
-    assert_device_equal(device, expected_device)
+    utils.assert_event_equal(event, expected_event)
+    utils.assert_device_equal(device, expected_device)
 
 
 @pytest.mark.django_db
-def test_poll_provider_v0_4_archives_no_result(client, requests_mock):
-    # Note: testing with the default "POLLER_CREATE_REGISTER_EVENTS = False"
+def test_poll_provider_archives_no_result(client, requests_mock):
     provider = factories.Provider(
         base_api_url="http://provider",
         api_configuration__api_version=enums.MDS_VERSIONS.v0_4.name,
@@ -292,7 +303,7 @@ def test_poll_provider_v0_4_archives_no_result(client, requests_mock):
     )
     call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
 
-    assert_command_success(stdout, stderr)
+    utils.assert_command_success(stdout, stderr)
     # The last poller cursor is updated
     provider = models.Provider.objects.get(pk=provider.pk)
     # No event but we won't ask this hour again
@@ -300,8 +311,7 @@ def test_poll_provider_v0_4_archives_no_result(client, requests_mock):
 
 
 @pytest.mark.django_db
-def test_poll_provider_v0_4_realtime(client, requests_mock):
-    # Note: testing with the default "POLLER_CREATE_REGISTER_EVENTS = False"
+def test_poll_provider_realtime(client, requests_mock):
     # This time we didn't poll long ago
     last_event_time_polled = timezone.now() - datetime.timedelta(3)
     provider = factories.Provider(
@@ -319,7 +329,7 @@ def test_poll_provider_v0_4_realtime(client, requests_mock):
     events = urllib.parse.urljoin(provider.base_api_url, "/events")
     requests_mock.get(
         events,
-        json=make_response(
+        json=utils.make_response(
             provider,
             expected_device,
             expected_event,
@@ -333,7 +343,7 @@ def test_poll_provider_v0_4_realtime(client, requests_mock):
     )
     call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
 
-    assert_command_success(stdout, stderr)
+    utils.assert_command_success(stdout, stderr)
     # The last poller cursor is updated
     provider = models.Provider.objects.get(pk=provider.pk)
     assert provider.last_event_time_polled != last_event_time_polled
@@ -343,13 +353,12 @@ def test_poll_provider_v0_4_realtime(client, requests_mock):
     # The actual event
     event = device.event_records.get()
     assert event.event_type == enums.EVENT_TYPE.service_start.name
-    assert_event_equal(event, expected_event)
-    assert_device_equal(device, expected_device)
+    utils.assert_event_equal(event, expected_event)
+    utils.assert_device_equal(device, expected_device)
 
 
 @pytest.mark.django_db
-def test_poll_provider_v0_4_lag(client, requests_mock):
-    # Note: testing with the default "POLLER_CREATE_REGISTER_EVENTS = False"
+def test_poll_provider_lag(client, requests_mock):
     # Below the lag threshold
     last_event_time_polled = timezone.now() - datetime.timedelta(minutes=30)
     provider = factories.Provider(
@@ -369,7 +378,7 @@ def test_poll_provider_v0_4_lag(client, requests_mock):
     )
     call_command("poll_providers", "--raise-on-error", stdout=stdout, stderr=stderr)
 
-    assert_command_success(stdout, stderr)
+    utils.assert_command_success(stdout, stderr)
     # The last poller cursor is NOT updated
     provider = models.Provider.objects.get(pk=provider.pk)
     assert provider.last_event_time_polled == last_event_time_polled
@@ -377,85 +386,3 @@ def test_poll_provider_v0_4_lag(client, requests_mock):
     assert models.Device.objects.count() == 0
     # No event created
     assert models.EventRecord.objects.count() == 0
-
-
-#
-# Utilities
-#
-
-
-def make_response(
-    provider,
-    device,
-    event,
-    event_type_reason,
-    associated_trip=None,
-    next_page=None,
-    version="0.3.0",
-):
-    assert event.event_type in [
-        event_type for event_type, *_ in dict(PROVIDER_REASON_TO_AGENCY_EVENT).values()
-    ]
-    telemetry = event.properties["telemetry"]
-
-    response = factories.ProviderStatusChangesBody(
-        version=version,
-        data__status_changes=[
-            factories.ProviderStatusChange(
-                provider_id=str(provider.pk),
-                provider_name=provider.name,
-                device_id=str(device.pk),
-                vehicle_id=device.identification_number,
-                vehicle_type=device.category,
-                event_type=PROVIDER_EVENT_TYPE_REASON_TO_EVENT_TYPE[event_type_reason],
-                event_type_reason=event_type_reason,
-                propulsion_type=device.propulsion,
-                event_time=int(event.timestamp.timestamp() * 1000),  # In ms
-                event_location__properties__timestamp=telemetry["timestamp"],
-                event_location__geometry__coordinates=[
-                    telemetry["gps"]["lng"],
-                    telemetry["gps"]["lat"],
-                ],
-                associated_trip=associated_trip,
-                recorded=int(event.timestamp.timestamp() * 1000),  # In ms
-            )
-        ],
-        links__next=next_page,
-    )
-    assert response["data"]["status_changes"][0]["event_location"]["geometry"][
-        "coordinates"
-    ] == [telemetry["gps"]["lng"], telemetry["gps"]["lat"]]
-    return response
-
-
-def assert_command_success(stdout, stderr):
-    assert not stderr.getvalue().strip(), """Command failed!
-stdout:
-%s
-stderr:
-%s
-""" % (
-        stdout.getvalue(),
-        stderr.getvalue(),
-    )
-
-
-def assert_device_equal(device, expected_device):
-    assert device.category == expected_device.category
-    assert device.identification_number == expected_device.identification_number
-    if device.model:
-        assert device.model == expected_device.model
-    assert device.propulsion == expected_device.propulsion
-
-
-def assert_event_equal(event, expected_event):
-    # These are not (yet?) in the provider API
-    del expected_event.properties["telemetry"]["gps"]["accuracy"]
-    del expected_event.properties["telemetry"]["gps"]["altitude"]
-    del expected_event.properties["telemetry"]["gps"]["heading"]
-    del expected_event.properties["telemetry"]["gps"]["speed"]
-    assert abs(event.timestamp - expected_event.timestamp) < datetime.timedelta(
-        seconds=0.001
-    )
-    assert event.point.json == expected_event.point.json
-    assert event.properties == expected_event.properties

--- a/tests/management/commands/utils.py
+++ b/tests/management/commands/utils.py
@@ -1,0 +1,87 @@
+"""
+Utilities
+"""
+import datetime
+
+from mds import factories
+from mds.provider_mapping import (
+    PROVIDER_REASON_TO_AGENCY_EVENT,
+    PROVIDER_EVENT_TYPE_REASON_TO_EVENT_TYPE,
+)
+
+
+def make_response(
+    provider,
+    device,
+    event,
+    event_type_reason,
+    associated_trip=None,
+    next_page=None,
+    version="0.3.0",
+):
+    assert event.event_type in [
+        event_type for event_type, *_ in dict(PROVIDER_REASON_TO_AGENCY_EVENT).values()
+    ]
+    telemetry = event.properties["telemetry"]
+
+    response = factories.ProviderStatusChangesBody(
+        version=version,
+        data__status_changes=[
+            factories.ProviderStatusChange(
+                provider_id=str(provider.pk),
+                provider_name=provider.name,
+                device_id=str(device.pk),
+                vehicle_id=device.identification_number,
+                vehicle_type=device.category,
+                event_type=PROVIDER_EVENT_TYPE_REASON_TO_EVENT_TYPE[event_type_reason],
+                event_type_reason=event_type_reason,
+                propulsion_type=device.propulsion,
+                event_time=int(event.timestamp.timestamp() * 1000),  # In ms
+                event_location__properties__timestamp=telemetry["timestamp"],
+                event_location__geometry__coordinates=[
+                    telemetry["gps"]["lng"],
+                    telemetry["gps"]["lat"],
+                ],
+                associated_trip=associated_trip,
+                recorded=int(event.timestamp.timestamp() * 1000),  # In ms
+            )
+        ],
+        links__next=next_page,
+    )
+    assert response["data"]["status_changes"][0]["event_location"]["geometry"][
+        "coordinates"
+    ] == [telemetry["gps"]["lng"], telemetry["gps"]["lat"]]
+    return response
+
+
+def assert_command_success(stdout, stderr):
+    assert not stderr.getvalue().strip(), """Command failed!
+stdout:
+%s
+stderr:
+%s
+""" % (
+        stdout.getvalue(),
+        stderr.getvalue(),
+    )
+
+
+def assert_device_equal(device, expected_device):
+    assert device.category == expected_device.category
+    assert device.identification_number == expected_device.identification_number
+    if device.model:
+        assert device.model == expected_device.model
+    assert device.propulsion == expected_device.propulsion
+
+
+def assert_event_equal(event, expected_event):
+    # These are not (yet?) in the provider API
+    del expected_event.properties["telemetry"]["gps"]["accuracy"]
+    del expected_event.properties["telemetry"]["gps"]["altitude"]
+    del expected_event.properties["telemetry"]["gps"]["heading"]
+    del expected_event.properties["telemetry"]["gps"]["speed"]
+    assert abs(event.timestamp - expected_event.timestamp) < datetime.timedelta(
+        seconds=0.001
+    )
+    assert event.point.json == expected_event.point.json
+    assert event.properties == expected_event.properties


### PR DESCRIPTION
But reuse as much code as possible.

The goal is to avoid branching in the code to support multiple versions,
and regressions in other versions when we adjust the code for another
one.

Most of the benefit can be seen in forking the tests to covers all cases
with both versions.

Closes: SMP-1691